### PR TITLE
Fix group name

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     post_install:
       - pip install poetry==1.6
       - poetry config virtualenvs.create false
-      - poetry install --with doc
+      - poetry install --with docs
 
 sphinx:
   configuration: docs/source/conf.py


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a typo in the .readthedocs.yaml configuration file by correcting the group name from 'doc' to 'docs' to ensure proper installation of documentation dependencies.

- **Bug Fixes**:
    - Corrected the group name from 'doc' to 'docs' in the .readthedocs.yaml configuration file.

<!-- Generated by sourcery-ai[bot]: end summary -->