### PR TITLE
Classifier typo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",
-  "Intended Audience :: Researchers",
+  "Intended Audience :: Science/Research",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## What does this PR do?

Solve a classifier typo.

## Summary by Sourcery

Chores:
- Corrected the PyPI classifier from 'Intended Audience :: Researchers' to the standard 'Intended Audience :: Science/Research'