### PR TITLE
Callback in sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 # lczerolens 🔍
 
-[![Python version](https://img.shields.io/pypi/pyversions/lczerolens.svg)](https://www.python.org/downloads/)
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/Xmaster6y/lczerolens/blob/main/LICENSE)
-<a href="https://pypi.org/project/lczerolens/"><img src="https://img.shields.io/pypi/v/lczerolens?color=purple"></img></a>
+[![lczerolens](https://img.shields.io/pypi/v/lczerolens?color=purple)](https://pypi.org/project/lczerolens/)
+[![license](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Xmaster6y/lczerolens/blob/main/LICENSE)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
+[![python versions](https://img.shields.io/pypi/pyversions/lczerolens.svg)](https://www.python.org/downloads/)
 ![ci](https://github.com/Xmaster6y/lczerolens/actions/workflows/ci.yml/badge.svg)
 ![publish](https://github.com/Xmaster6y/lczerolens/actions/workflows/publish.yml/badge.svg)
 [![docs](https://readthedocs.org/projects/lczerolens/badge/?version=latest)](https://lczerolens.readthedocs.io/en/latest/?badge=latest)

--- a/src/lczerolens/lenses/sae/buffer.py
+++ b/src/lczerolens/lenses/sae/buffer.py
@@ -33,7 +33,7 @@ class ActivationBuffer:
             DataLoader(self.dataset, batch_size=self.compute_batch_size, **self.dataloader_kwargs)
         )
 
-    @torch.no_grad
+    @torch.no_grad()
     def _fill_buffer(self):
         if self.logger is not None:
             self.logger.info("Computing activations...")

--- a/src/lczerolens/play/sampling.py
+++ b/src/lczerolens/play/sampling.py
@@ -103,7 +103,7 @@ class ModelSampler(Sampler):
             return board.decode_move(legal_indices[idx])
         return super().choose_move(board, utility, legal_indices)
 
-    @torch.no_grad
+    @torch.no_grad()
     def get_utilities(
         self, boards: Iterable[LczeroBoard], **kwargs
     ) -> Iterable[Tuple[torch.Tensor, torch.Tensor, Dict[str, float]]]:
@@ -183,7 +183,7 @@ class ModelSampler(Sampler):
 class PolicySampler(ModelSampler):
     use_suboptimal: bool = False
 
-    @torch.no_grad
+    @torch.no_grad()
     def get_utilities(
         self, boards: Iterable[LczeroBoard], **kwargs
     ) -> Iterable[Tuple[torch.Tensor, torch.Tensor, Dict[str, float]]]:


### PR DESCRIPTION
## What does this PR do?

Add a callback in samplers.

## Linked Issues

- Closes #63

## Summary by Sourcery

Add a callback mechanism to samplers to allow for custom logging and processing during utility computation

New Features:
- Introduce a flexible callback mechanism in ModelSampler and PolicySampler that allows users to inject custom processing during sampling

Enhancements:
- Modify samplers to accept an optional callback function that can augment logging information during utility computation

Chores:
- Update decorator syntax for @torch.no_grad to use parentheses
- Update README badges