### PR TITLE
Fixed Python versions tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,50 +4,22 @@ on:
   pull_request:
 
 jobs:
-  ci-python-3_10:
+  ci:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
     environment: ci
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
       with:
-        python-version: "3.11"
-    - name: Run Python commands
-      run: |
-        pip install --upgrade pip
-        pip install uv
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-        uv sync --python 3.10 --locked
-    - name: Run checks
-      run: |
-        make checks
-    - name: Download assets
-      run: |
-        make test-assets
-    - name: Run tests
-      run: |
-        make tests
-
-  ci-python-3_11:
-    runs-on: ubuntu-latest
-    environment: ci
-    timeout-minutes: 10
-    steps:
-    - uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.11"
-    - name: Run Python commands
-      run: |
-        pip install --upgrade pip
-        pip install uv
-    - name: Install dependencies
-      run: |
-        uv sync --python 3.11 --locked
+        uv sync --locked
     - name: Run checks
       run: |
         make checks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,25 +9,19 @@ permissions:
 
 jobs:
   deploy:
-
     runs-on: ubuntu-latest
     environment: publish
     permissions:
       id-token: write
-
     steps:
-    - uses: actions/checkout@v3
-    - name: Setup Python
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
       with:
         python-version: "3.11"
-    - name: Run Python commands
-      run: |
-        pip install --upgrade pip
-        pip install uv
     - name: Install dependencies
       run: |
-        uv sync
+        uv sync --locked
     - name: Build package
       run: |
         uv build

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv sync
+    - uv sync --locked
     - make docs
     - mkdir -p $READTHEDOCS_OUTPUT
     - mv docs/build/html $READTHEDOCS_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
 ]
 
 [project.urls]


### PR DESCRIPTION
## What does this PR do?

Previous CIs didn't properly test Python versions.

## Summary by Sourcery

Update CI workflow to test against Python 3.10, 3.11, and 3.12 using a matrix strategy and modernize dependency management with `uv`.

CI:
- Consolidate CI jobs into a single matrix strategy for Python versions 3.10, 3.11, and 3.12.
- Replace `actions/setup-python` with `astral-sh/setup-uv` for Python and `uv` setup.
- Upgrade `actions/checkout` to v4.
- Use locked dependencies (`uv sync --locked`) for installation.

Deployment:
- Update the publish workflow to use `astral-sh/setup-uv`.
- Upgrade `actions/checkout` to v4 in the publish workflow.
- Install locked dependencies using `uv sync --locked` in the publish workflow.

Chores:
- Declare support for Python 3.12 in `pyproject.toml`.