### PR TITLE
Improve build workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Store assets
       uses: actions/upload-artifact@v4
       with:
-        name: package-${{ inputs.version }}-${{ strategy.job-index }}
+        name: package-${{ strategy.job-index }}
         path: dist
 
   publish:
@@ -50,7 +50,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        pattern: package-${{ inputs.version }}-*
+        pattern: package-*
         merge-multiple: true
         path: dist
     - name: Publish package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: cp{310,311,312}*
+        CIBW_BUILD: cp{310,311,312}-{macosx_arm64,manylinux_x86_64}
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       uses: astral-sh/setup-uv@v5
       if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.11"
     - name: Build package
       if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         output-dir: dist
       env:
-        CIBW_BUILD: cp{310,311,312}-{macosx_arm64,manylinux_x86_64}
+        CIBW_BUILD: cp{310,311,312}-{macosx,manylinux,win,win32}{_arm64,_x86_64}
     - name: Install uv
       uses: astral-sh/setup-uv@v5
       if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,20 +40,20 @@ jobs:
         name: package-${{ inputs.version }}-${{ strategy.job-index }}
         path: dist
 
-  # publish:
-  #   needs: build
-  #   runs-on: ubuntu-latest
-  #   environment: publish
-  #   permissions:
-  #     id-token: write
-  #   steps:
-  #   - name: Download all the dists
-  #     uses: actions/download-artifact@v4
-  #     with:
-  #       pattern: package-${{ inputs.version }}-*
-  #       merge-multiple: true
-  #       path: dist
-  #   - name: Publish package
-  #     uses: pypa/gh-action-pypi-publish@release/v1
-  #     with:
-  #       packages-dir: dist
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: publish
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        pattern: package-${{ inputs.version }}-*
+        merge-multiple: true
+        path: dist
+    - name: Publish package
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,29 +1,59 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
-permissions:
-  contents: read
-
 jobs:
-  deploy:
-    runs-on: ubuntu-latest
+  build:
+    strategy:
+      matrix:
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+    runs-on: ${{ matrix.os }}
     environment: publish
     permissions:
       id-token: write
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        submodules: true
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.23.3
+      with:
+        output-dir: dist
+      env:
+        CIBW_BUILD: cp{310,311,312}*
     - name: Install uv
       uses: astral-sh/setup-uv@v5
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       with:
-        python-version: "3.11"
-    - name: Install dependencies
-      run: |
-        uv sync --locked
+        python-version: ${{ matrix.python-version }}
     - name: Build package
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
-        uv build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+        uv build --sdist
+    - name: Store assets
+      uses: actions/upload-artifact@v4
+      with:
+        name: package-${{ inputs.version }}-${{ strategy.job-index }}
+        path: dist
+
+  # publish:
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   environment: publish
+  #   permissions:
+  #     id-token: write
+  #   steps:
+  #   - name: Download all the dists
+  #     uses: actions/download-artifact@v4
+  #     with:
+  #       pattern: package-${{ inputs.version }}-*
+  #       merge-multiple: true
+  #       path: dist
+  #   - name: Publish package
+  #     uses: pypa/gh-action-pypi-publish@release/v1
+  #     with:
+  #       packages-dir: dist


### PR DESCRIPTION
## What does this PR do?

Improve build workflow.

## Linked Issues

- Closes #71

## Summary by Sourcery

Enhance the GitHub Actions workflow for building and publishing Python packages across multiple platforms

CI:
- Restructure publish workflow to build wheels for multiple operating systems
- Add support for building wheels for Python 3.10, 3.11, and 3.12
- Separate build and publish stages in the workflow

Chores:
- Update GitHub Actions workflow to use latest actions and build tools