### PR TITLE
Rollback publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,59 +1,29 @@
 name: Publish
 
 on:
-  workflow_dispatch:
   release:
     types: [published]
 
-jobs:
-  build:
-    strategy:
-      matrix:
-        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-    runs-on: ${{ matrix.os }}
-    environment: publish
-    permissions:
-      id-token: write
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: true
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23.3
-      with:
-        output-dir: dist
-      env:
-        CIBW_BUILD: cp{310,311,312}-{macosx,manylinux,win,win32}{_arm64,_x86_64}
-    - name: Install uv
-      uses: astral-sh/setup-uv@v5
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      with:
-        python-version: "3.11"
-    - name: Build package
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        uv build --sdist
-    - name: Store assets
-      uses: actions/upload-artifact@v4
-      with:
-        name: package-${{ strategy.job-index }}
-        path: dist
+permissions:
+  contents: read
 
-  publish:
-    needs: build
+jobs:
+  deploy:
     runs-on: ubuntu-latest
     environment: publish
     permissions:
       id-token: write
     steps:
-    - name: Download all the dists
-      uses: actions/download-artifact@v4
+    - uses: actions/checkout@v4
+    - name: Install uv
+      uses: astral-sh/setup-uv@v5
       with:
-        pattern: package-*
-        merge-multiple: true
-        path: dist
+        python-version: "3.11"
+    - name: Install dependencies
+      run: |
+        uv sync --locked
+    - name: Build package
+      run: |
+        uv build
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        packages-dir: dist

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,11 +1,9 @@
 name: Publish
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
-
-permissions:
-  contents: read
 
 jobs:
   deploy:


### PR DESCRIPTION
## What does this PR do?

Platform builds are not needed.

## Summary by Sourcery

Simplify the publish workflow by removing platform-specific build steps and consolidating the build and publish jobs

CI:
- Removed multi-platform build matrix
- Consolidated build and publish steps into a single job

Chores:
- Simplified GitHub Actions workflow for package publishing