### PR TITLE
New backends demo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "spaces/lczerolens-demo"]
 	path = spaces/lczerolens-demo
 	url = https://huggingface.co/spaces/lczerolens/lczerolens-demo
+[submodule "spaces/lczerolens-backends-demo"]
+	path = spaces/lczerolens-backends-demo
+	url = https://huggingface.co/spaces/lczerolens/lczerolens-backends-demo

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,7 @@ docs:
 .PHONY: demo
 demo:
 	uv run --group demo gradio spaces/lczerolens-demo/app.py
+
+.PHONY: demo-backends
+demo-backends:
+	uv run --group demo gradio spaces/lczerolens-backends-demo/app.py

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ And then launch the demo (running on port `8000`):
 make demo
 ```
 
+To test the backends use:
+
+```bash
+make demo-backends
+```
+
 ## Full Documentation
 
 See the full [documentation](https://lczerolens.readthedocs.io).

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ pip install lczerolens
 ### Spaces
 
 - [Lczerolens Demo](https://huggingface.co/spaces/lczerolens/lczerolens-demo)
+- [Lczerolens Backends Demo](https://huggingface.co/spaces/lczerolens/lczerolens-backends-demo)
 - [Lczerolens Puzzles Leaderboard](https://huggingface.co/spaces/lczerolens/lichess-puzzles-leaderboard)
 
 ### Local Demo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,17 +39,20 @@ releasenotes = "https://github.com/Xmaster6y/lczerolens/releases"
 viz = [
     "matplotlib>=3.10.0",
 ]
+backends = [
+    "v-lczero-bindings>=0.31.2"
+]
 
 [dependency-groups]
 dev = [
     "gdown>=5.2.0",
     "ipykernel>=6.29.5",
-    "lczero-bindings",
     "nbconvert>=7.16.5",
     "onnxruntime>=1.20.1",
     "pre-commit>=4.0.1",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
+    "v-lczero-bindings>=0.31.2",
 ]
 demo = [
     "gradio>=5.12.0",
@@ -82,10 +85,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-default-groups = ["dev"]
-
-[tool.uv.sources]
-lczero-bindings = { git = "https://github.com/LeelaChessZero/lc0.git", rev = "dfcd1c314150b93125697491bef1221841443c18" }
+default-groups = ["dev", "demo"]
 
 [tool.ruff]
 line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ dev = [
 demo = [
     "gradio>=5.12.0",
     "matplotlib>=3.10.0",
+    "v-lczero-bindings>=0.31.2",
 ]
 docs = [
     "nbsphinx>=0.9.6",
@@ -85,7 +86,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.uv]
-default-groups = ["dev", "demo"]
+default-groups = ["dev"]
 
 [tool.ruff]
 line-length = 119

--- a/src/lczerolens/backends.py
+++ b/src/lczerolens/backends.py
@@ -3,7 +3,7 @@
 Notes
 ----
 The lczero bindings are not installed by default. You can install them by
-running `pip install lczero`.
+running `pip install lczerolens[backends]`.
 """
 
 import subprocess
@@ -16,7 +16,9 @@ from lczerolens.board import LczeroBoard
 try:
     from lczero.backends import Backend, GameState
 except ImportError as e:
-    raise ImportError("LCZero bindings are not installed.See https://github.com/LeelaChessZero/lc0.git.") from e
+    raise ImportError(
+        "LCZero bindings are required to use the backends, install them with `pip install lczerolens[backends]`."
+    ) from e
 
 
 def generic_command(args, verbose=False):

--- a/uv.lock
+++ b/uv.lock
@@ -1458,6 +1458,7 @@ viz = [
 demo = [
     { name = "gradio" },
     { name = "matplotlib" },
+    { name = "v-lczero-bindings" },
 ]
 dev = [
     { name = "gdown" },
@@ -1507,6 +1508,7 @@ requires-dist = [
 demo = [
     { name = "gradio", specifier = ">=5.12.0" },
     { name = "matplotlib", specifier = ">=3.10.0" },
+    { name = "v-lczero-bindings", specifier = ">=0.31.2" },
 ]
 dev = [
     { name = "gdown", specifier = ">=5.2.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1431,11 +1431,6 @@ wheels = [
 ]
 
 [[package]]
-name = "lczero-bindings"
-version = "0.1.0"
-source = { git = "https://github.com/LeelaChessZero/lc0.git?rev=dfcd1c314150b93125697491bef1221841443c18#dfcd1c314150b93125697491bef1221841443c18" }
-
-[[package]]
 name = "lczerolens"
 version = "0.3.2.dev0"
 source = { editable = "." }
@@ -1452,6 +1447,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+backends = [
+    { name = "v-lczero-bindings" },
+]
 viz = [
     { name = "matplotlib" },
 ]
@@ -1464,12 +1462,12 @@ demo = [
 dev = [
     { name = "gdown" },
     { name = "ipykernel" },
-    { name = "lczero-bindings" },
     { name = "nbconvert" },
     { name = "onnxruntime" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "v-lczero-bindings" },
 ]
 docs = [
     { name = "nbsphinx" },
@@ -1502,6 +1500,7 @@ requires-dist = [
     { name = "scikit-learn", specifier = ">=1.6.1" },
     { name = "tensordict", specifier = ">=0.6.2" },
     { name = "typing-extensions", specifier = ">=4.12.2" },
+    { name = "v-lczero-bindings", marker = "extra == 'backends'", specifier = ">=0.31.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -1512,12 +1511,12 @@ demo = [
 dev = [
     { name = "gdown", specifier = ">=5.2.0" },
     { name = "ipykernel", specifier = ">=6.29.5" },
-    { name = "lczero-bindings", git = "https://github.com/LeelaChessZero/lc0.git?rev=dfcd1c314150b93125697491bef1221841443c18" },
     { name = "nbconvert", specifier = ">=7.16.5" },
     { name = "onnxruntime", specifier = ">=1.20.1" },
     { name = "pre-commit", specifier = ">=4.0.1" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "v-lczero-bindings", specifier = ">=0.31.2" },
 ]
 docs = [
     { name = "nbsphinx", specifier = ">=0.9.6" },
@@ -4066,6 +4065,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+]
+
+[[package]]
+name = "v-lczero-bindings"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/6f/e9f713a35959ec2e931a0651933ef0b431fbceff952d7e3207eaa8c9faae/v_lczero_bindings-0.31.2.tar.gz", hash = "sha256:cca35d3df155b7a11993d24f5ba8800e9262ce6fc11efab4987fc4a10f4ffb10", size = 712343 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a4/4109483502ffb745fc80a31cfd2c71e8eea039ec541f2e8a96e213c62432/v_lczero_bindings-0.31.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:96436dd32ee708dc7753bff55a9b147a616d9911b7d323c35ac3bb45ca7e1960", size = 3305656 },
+    { url = "https://files.pythonhosted.org/packages/7e/5f/8515c419dcac6047a6334072af75bbff9377c375c06ed4289be8978075d7/v_lczero_bindings-0.31.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6ac680c093a7377de0c4762bf33d75325c4c946f84c98537c654147b3debbfd6", size = 3262084 },
+    { url = "https://files.pythonhosted.org/packages/23/2d/d31d71a3e263278feebd8da78010d8adc0973016b3298bb241a520cef625/v_lczero_bindings-0.31.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:edd5ba4b4df39ed2c992c7fa892acd7877fd8b5a3107ec3220b2bf05f9074810", size = 3305655 },
+    { url = "https://files.pythonhosted.org/packages/d7/56/5f76ba836a1964afd831669bf041ce7418aee0221f4e6626054b08402b2f/v_lczero_bindings-0.31.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ae63c6bea9132ddc8cbecff0ecb5a39817dd073e89442c3baba303a46b65cb10", size = 3262083 },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/90bd7f329a5b3c1c3c293ae5a46dc2e39c7f97cbc058f45d84102f2a84aa/v_lczero_bindings-0.31.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ddae9aa8cf9a20cc062702d77b01bc9f5c01071e6335fd7072677b296914b33e", size = 3305656 },
+    { url = "https://files.pythonhosted.org/packages/7c/e1/567402d644beaea472bbb09237b9e55cca3f337e2499e4f25464128619e6/v_lczero_bindings-0.31.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a0a820d8b05c63abd019cc3ca032d1405644fdf973c72b65bbb3fe234206bf2d", size = 3262235 },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Add the backends demo.

## Linked Issues

- Closes #73

## Summary by Sourcery

Add a new backends demo for the lczerolens project, updating dependencies and project configuration to support the new demo.

New Features:
- Add a new backends demo space
- Introduce a new demo-backends make target

Enhancements:
- Update dependency management to use v-lczero-bindings
- Improve error messaging for LCZero bindings import

Deployment:
- Add new Hugging Face Space for Lczerolens Backends Demo

Documentation:
- Update README with instructions for running backends demo