### PR TITLE
Run backends tests in CI

### DIFF
--- a/.github/workflows/ci-backends.yml
+++ b/.github/workflows/ci-backends.yml
@@ -1,0 +1,10 @@
+name: CI (backends)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  ci:
+    uses: ./.github/workflows/ci.yml
+    with:
+      tests-type: tests-backends

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,10 @@ tests-fast:
 tests-slow:
 	uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -s -v --onlyslow --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
+.PHONY: tests-backends
+tests-backends:
+	uv run pytest tests --cov=src --cov-report=term-missing --cov-fail-under=50 -s -v --onlybackends --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
+
 .PHONY: docs
 docs:
 	cd docs && uv run --group docs make html

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,7 @@ def winner_senet_ort(winner_ensure_network):
 def pytest_addoption(parser):
     parser.addoption("--onlyslow", action="store_true", default=False, help="run slow tests only")
     parser.addoption("--onlyfast", action="store_true", default=False, help="run fast tests only")
+    parser.addoption("--onlybackends", action="store_true", default=False, help="run backends tests only")
 
 
 def pytest_configure(config):
@@ -89,3 +90,8 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "slow" in item.keywords:
                 item.add_marker(skip_slow)
+    elif config.getoption("--onlybackends"):
+        skip_backends = pytest.mark.skip(reason="--onlybackends given in cli: skipping non-backends tests")
+        for item in items:
+            if "backends" not in item.keywords:
+                item.add_marker(skip_backends)

--- a/tests/unit/core/test_board.py
+++ b/tests/unit/core/test_board.py
@@ -2,7 +2,6 @@
 Tests for the board utils.
 """
 
-import sys
 from typing import List, Tuple
 import pytest
 import chess
@@ -13,7 +12,7 @@ from lczerolens import LczeroBoard
 
 
 class TestWithBackend:
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, random_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -28,7 +27,7 @@ class TestWithBackend:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, random_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -47,7 +46,7 @@ class TestWithBackend:
 
 
 class TestRepetition:
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, repetition_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -62,7 +61,7 @@ class TestRepetition:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, repetition_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -79,7 +78,7 @@ class TestRepetition:
 
 
 class TestLong:
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, long_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -94,7 +93,7 @@ class TestLong:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, long_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -124,7 +123,7 @@ class TestStability:
 
 
 class TestBackend:
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_encode_decode_random(self, random_move_board_list):
         """
         Test that encoding and decoding a move corresponds to the backend.
@@ -143,7 +142,7 @@ class TestBackend:
             assert len(lczero_policy_indices) == len(policy_indices)
             assert set(lczero_policy_indices) == set(policy_indices)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_encode_decode_long(self, long_move_board_list):
         """
         Test that encoding and decoding a move corresponds to the backend.

--- a/tests/unit/core/test_lczero.py
+++ b/tests/unit/core/test_lczero.py
@@ -2,7 +2,6 @@
 LCZero utils tests.
 """
 
-import sys
 import torch
 import pytest
 from lczero.backends import GameState
@@ -35,7 +34,7 @@ class TestExecution:
         assert isinstance(generic_command, str)
         assert "Usage: lc0" in generic_command
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_board_from_backend(self, tiny_lczero_backend):
         """
         Test that the board from backend function works.
@@ -44,7 +43,7 @@ class TestExecution:
         lczero_board_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game)
         assert lczero_board_tensor.shape == (112, 8, 8)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_prediction_from_backend(self, tiny_lczero_backend):
         """
         Test that the prediction from backend function works.

--- a/tests/unit/core/test_model.py
+++ b/tests/unit/core/test_model.py
@@ -2,7 +2,6 @@
 
 import pytest
 import torch
-import sys
 from lczero.backends import GameState
 
 from lczerolens import Flow, LczeroBoard
@@ -14,7 +13,7 @@ class TestModel:
         """Test that the model loads."""
         tiny_model
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_model_prediction(self, tiny_lczero_backend, tiny_model):
         """Test that the model prediction works."""
         board = LczeroBoard()
@@ -26,7 +25,7 @@ class TestModel:
         assert torch.allclose(policy, lczero_policy, atol=1e-4)
         assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_model_prediction_random(self, tiny_lczero_backend, tiny_model, random_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = random_move_board_list
@@ -39,7 +38,7 @@ class TestModel:
             assert torch.allclose(policy, lczero_policy, atol=1e-4)
             assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_model_prediction_repetition(self, tiny_lczero_backend, tiny_model, repetition_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = repetition_move_board_list
@@ -52,7 +51,7 @@ class TestModel:
             assert torch.allclose(policy, lczero_policy, atol=1e-4)
             assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="lczero.backends is only supported on Python 3.9")
+    @pytest.mark.backends
     def test_model_prediction_long(self, tiny_lczero_backend, tiny_model, long_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = long_move_board_list


### PR DESCRIPTION
## Summary by Sourcery

Introduce dedicated selection and CI pipeline for backend tests by replacing Python version skips with a pytest marker, adding a --onlybackends flag, updating the Makefile, and defining a new GitHub Actions workflow.

Enhancements:
- Replace version-based skips in backend-related tests with pytest.mark.backends.

Build:
- Add a Makefile target `tests-backends` to run only backend tests.

CI:
- Add a `ci-backends.yml` GitHub Actions workflow to execute the backend test suite.

Tests:
- Add a --onlybackends CLI option and configure pytest to skip non-backend tests.