### PR TITLE
Fixed error in Pytest config

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "backends: mark test as backends test")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/unit/core/test_board.py
+++ b/tests/unit/core/test_board.py
@@ -11,8 +11,8 @@ from lczerolens import backends as lczero_utils
 from lczerolens import LczeroBoard
 
 
+@pytest.mark.backends
 class TestWithBackend:
-    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, random_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -27,7 +27,6 @@ class TestWithBackend:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, random_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -45,8 +44,8 @@ class TestWithBackend:
                 assert (board_tensor[plane] == lczero_input_tensor[plane]).all()
 
 
+@pytest.mark.backends
 class TestRepetition:
-    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, repetition_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -61,7 +60,6 @@ class TestRepetition:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, repetition_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -77,8 +75,8 @@ class TestRepetition:
             assert (board_tensor == lczero_input_tensor).all()
 
 
+@pytest.mark.backends
 class TestLong:
-    @pytest.mark.backends
     def test_board_to_config_tensor(
         self, long_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -93,7 +91,6 @@ class TestLong:
             lczero_input_tensor = lczero_utils.board_from_backend(tiny_lczero_backend, lczero_game, planes=13)
             assert (board_tensor == lczero_input_tensor[:13]).all()
 
-    @pytest.mark.backends
     def test_board_to_input_tensor(
         self, long_move_board_list: Tuple[List[chess.Move], List[LczeroBoard]], tiny_lczero_backend
     ):
@@ -122,8 +119,8 @@ class TestStability:
             us, them = them, us
 
 
+@pytest.mark.backends
 class TestBackend:
-    @pytest.mark.backends
     def test_encode_decode_random(self, random_move_board_list):
         """
         Test that encoding and decoding a move corresponds to the backend.
@@ -142,7 +139,6 @@ class TestBackend:
             assert len(lczero_policy_indices) == len(policy_indices)
             assert set(lczero_policy_indices) == set(policy_indices)
 
-    @pytest.mark.backends
     def test_encode_decode_long(self, long_move_board_list):
         """
         Test that encoding and decoding a move corresponds to the backend.

--- a/tests/unit/core/test_model.py
+++ b/tests/unit/core/test_model.py
@@ -8,12 +8,8 @@ from lczerolens import Flow, LczeroBoard
 from lczerolens import backends as lczero_utils
 
 
+@pytest.mark.backends
 class TestModel:
-    def test_load_model(self, tiny_model):
-        """Test that the model loads."""
-        tiny_model
-
-    @pytest.mark.backends
     def test_model_prediction(self, tiny_lczero_backend, tiny_model):
         """Test that the model prediction works."""
         board = LczeroBoard()
@@ -25,7 +21,6 @@ class TestModel:
         assert torch.allclose(policy, lczero_policy, atol=1e-4)
         assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.backends
     def test_model_prediction_random(self, tiny_lczero_backend, tiny_model, random_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = random_move_board_list
@@ -38,7 +33,6 @@ class TestModel:
             assert torch.allclose(policy, lczero_policy, atol=1e-4)
             assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.backends
     def test_model_prediction_repetition(self, tiny_lczero_backend, tiny_model, repetition_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = repetition_move_board_list
@@ -51,7 +45,6 @@ class TestModel:
             assert torch.allclose(policy, lczero_policy, atol=1e-4)
             assert torch.allclose(value, lczero_value, atol=1e-4)
 
-    @pytest.mark.backends
     def test_model_prediction_long(self, tiny_lczero_backend, tiny_model, long_move_board_list):
         """Test that the model prediction works."""
         move_list, board_list = long_move_board_list


### PR DESCRIPTION
## Summary by Sourcery

Register and streamline the use of a custom 'backends' pytest marker across core unit tests

Bug Fixes:
- Fix pytest configuration error by registering the 'backends' marker in pytest_configure

Tests:
- Define the 'backends' marker in conftest.py and apply it at the class level in board and model tests, removing individual method annotations