### PR TITLE
Fixed `GradientLens` with `_grad_enabled` attribute

### DIFF
--- a/src/lczerolens/lenses/gradient.py
+++ b/src/lczerolens/lenses/gradient.py
@@ -8,6 +8,8 @@ from lczerolens.lens import Lens
 class GradientLens(Lens):
     """Class for gradient-based XAI methods."""
 
+    _grad_enabled: bool = True
+
     def __init__(self, *, input_requires_grad: bool = True, **kwargs):
         self.input_requires_grad = input_requires_grad
         super().__init__(**kwargs)

--- a/tests/unit/lenses/test_gradient.py
+++ b/tests/unit/lenses/test_gradient.py
@@ -1,0 +1,36 @@
+"""Gradient lens tests."""
+
+from lczerolens import Lens
+from lczerolens.lenses import GradientLens
+from lczerolens.board import LczeroBoard
+
+
+class TestLens:
+    def test_is_compatible(self, tiny_model):
+        lens = Lens.from_name("gradient")
+        assert isinstance(lens, GradientLens)
+        assert lens.is_compatible(tiny_model)
+
+    def test_analyse_board(self, tiny_model):
+        lens = GradientLens()
+        board = LczeroBoard()
+        results = lens.analyse(tiny_model, board)
+
+        assert "input_grad" in results
+
+    def test_analyse_without_input_grad(self, tiny_model):
+        lens = GradientLens(input_requires_grad=False)
+        board = LczeroBoard()
+        results = lens.analyse(tiny_model, board)
+
+        assert "input_grad" not in results
+
+    def test_analyse_specific_modules(self, tiny_model):
+        lens = GradientLens(pattern=r".*conv.*relu", input_requires_grad=False)
+        board = LczeroBoard()
+        results = lens.analyse(tiny_model, board)
+
+        assert len(results) > 0
+        for key in results:
+            module_name = key.replace("_output_grad", "")
+            assert "conv" in module_name


### PR DESCRIPTION
## Summary by Sourcery

Fix `GradientLens` by adding an internal flag to control gradient computation state, ensure `input_requires_grad` correctly includes or omits input gradients, and add unit tests covering compatibility, input gradient toggling, and module-specific gradient filtering.

Bug Fixes:
- Ensure `input_requires_grad=False` disables inclusion of input gradients in analysis results.

Enhancements:
- Introduce an internal `_grad_enabled` flag in `GradientLens` to track and manage gradient computation state.

Tests:
- Add unit tests for lens compatibility with models.
- Add tests to verify inclusion and exclusion of `input_grad` based on `input_requires_grad`.
- Add tests for module-specific gradient analysis using a pattern filter.