### PR TITLE
[Chore] Better AI support

### DIFF
--- a/docs/source/about.rst
+++ b/docs/source/about.rst
@@ -40,7 +40,7 @@ Key chess engines and AI systems:
 - `Maia <https://www.maiachess.com/>`_ - Human-like chess playing neural network
 
 Technical Background
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Understanding probabilities and search:
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -107,5 +107,5 @@ nbsphinx_execute = "never"
 # Autoapi
 autoapi_dirs = ["../../src"]
 autoapi_root = "api"
-autoapi_keep_files = False
+autoapi_keep_files = True  # Weird rtd fail
 autodoc_typehints = "description"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ extensions = [
     "sphinx_design",  # Boostrap design components
     "nbsphinx",  # Jupyter notebook support
     "autoapi.extension",
+    "sphinx_llm.txt",
 ]
 
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,8 +102,7 @@ html_css_files = [
 ]
 
 # Nbsphinx
-nbsphinx_execute = "auto"
-nbsphinx_allow_errors = True
+nbsphinx_execute = "never"
 
 # Autoapi
 autoapi_dirs = ["../../src"]

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -168,3 +168,4 @@ Features
    notebooks/features/convert-official-weights.ipynb
    notebooks/features/visualise-heatmaps.ipynb
    notebooks/features/probe-concepts.ipynb
+   notebooks/features/selfplay-mcts-nn.ipynb

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -14,6 +14,18 @@ Tutorials
 
       :bdg-primary:`Main Features`
 
+   .. grid-item-card:: Automated Interpretability
+      :link: notebooks/tutorials/automated-interpretability.ipynb
+
+   .. grid-item-card:: Evidence of Learned Look-Ahead
+      :link: notebooks/tutorials/evidence-of-learned-look-ahead.ipynb
+
+   .. grid-item-card:: Piece Value Estimation Using LRP
+      :link: notebooks/tutorials/piece-value-estimation-using-lrp.ipynb
+
+   .. grid-item-card:: Train SAEs
+      :link: notebooks/tutorials/train-saes.ipynb
+
 .. toctree::
    :hidden:
    :maxdepth: 2

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -20,3 +20,7 @@ Tutorials
 
    notebooks/walkthrough.ipynb
    notebooks/tutorials/framework-agnostic-interpretability.ipynb
+   notebooks/tutorials/automated-interpretability.ipynb
+   notebooks/tutorials/evidence-of-learned-look-ahead.ipynb
+   notebooks/tutorials/piece-value-estimation-using-lrp.ipynb
+   notebooks/tutorials/train-saes.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ docs = [
     "sphinx-charts>=0.2.1",
     "sphinx-copybutton>=0.5.2",
     "sphinx-design>=0.6.1",
+    "sphinx-llm>=0.3.0",
 ]
 scripts = [
     "loguru>=0.7.3",

--- a/skills/lczerolens/SKILL.md
+++ b/skills/lczerolens/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: lczerolens
+description: Provides guidance for interpretability of Leela Chess Zero (lc0) neural networks. Use when loading lc0 models, encoding chess boards, running inference, visualizing heatmaps, probing concepts, evaluating on puzzles, or pairing with tdhook, captum, zennit, or nnsight for XAI.
+version: 1.0.0
+author: Xmaster6y
+license: MIT
+tags: [lczerolens, lc0, Chess, Interpretability, Leela Chess Zero, TensorDict, PyTorch, Heatmaps, Probing, Concepts]
+dependencies: [lczerolens, tensordict>=0.9.1, torch>=2.5.0, python-chess>=1.999]
+---
+
+# lczerolens
+
+Interpretability for Leela Chess Zero (lc0) networks. Framework-agnostic (PyTorch): pair with `tdhook`, `captum`, `zennit`, or `nnsight`.
+
+**Docs**: [lczerolens.readthedocs.io](https://lczerolens.readthedocs.io) · **GitHub**: [Xmaster6y/lczerolens](https://github.com/Xmaster6y/lczerolens)
+
+## When to Use
+
+**Use lczerolens when you need to:**
+- Load and run lc0 models (ONNX, PyTorch, Hugging Face Hub)
+- Encode chess boards into 112×8×8 input tensors
+- Run interpretability methods (attribution, probing, LRP) on chess NNs
+- Visualize saliency heatmaps on the board
+- Probe concepts (material, threats, best move) on board representations
+- Evaluate models on puzzles or games
+- Use MCTS, policy/value sampling, or self-play
+
+**Consider alternatives:** tdhook (attribution, probing, steering), nnsight (remote 70B+), general chess engines (Stockfish) for non-NN analysis.
+
+---
+
+## Workflow 1: Load Model and Run Inference
+
+**Goal**: Get policy and value predictions for a chess position.
+
+**Checklist**:
+- [ ] Load model: `LczeroModel.from_hf(repo_id)` or `from_path(path)`
+- [ ] Create board: `LczeroBoard()` or `LczeroBoard(fen)`
+- [ ] Call `model(board)` → TensorDict with `policy`, `wdl`/`value`, optionally `mlh`
+- [ ] Use `board.decode_move(idx)` for move index → UCI
+
+```python
+from lczerolens import LczeroBoard, LczeroModel
+
+model = LczeroModel.from_hf("lczerolens/maia-1100")
+board = LczeroBoard()
+
+output = model(board)
+best_move_idx = output["policy"].argmax().item()
+print(board.decode_move(best_move_idx))
+```
+
+---
+
+## Workflow 2: Encode Boards and Prepare Inputs
+
+**Goal**: Convert chess positions to model input tensors.
+
+**Checklist**:
+- [ ] Use `board.to_input_tensor(input_encoding=...)` for 112×8×8 tensor
+- [ ] Default: `InputEncoding.INPUT_CLASSICAL_112_PLANE` (8 history planes + castling, color, etc.)
+- [ ] For model: `model.prepare_boards(board1, board2, ...)` batches boards
+- [ ] Move encoding: `LczeroBoard.encode_move(move, us)` and `board.decode_move(index)`
+
+```python
+from lczerolens import LczeroBoard
+from lczerolens.board import InputEncoding
+
+board = LczeroBoard("r1bqkbnr/pppppppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1")
+tensor = board.to_input_tensor(input_encoding=InputEncoding.INPUT_CLASSICAL_112_PLANE)
+# tensor shape: (112, 8, 8)
+```
+
+---
+
+## Workflow 3: Framework-Agnostic Interpretability (tdhook)
+
+**Goal**: Run attribution, probing, or patching with tdhook on lc0 models.
+
+**Checklist**:
+- [ ] lczerolens uses `in_keys=["board"]`, `out_keys=["policy","wdl",...]`
+- [ ] Build TensorDict: `TensorDict({"board": x}, batch_size=...)`
+- [ ] For tdhook: pass `in_keys=["board"]`, `out_keys=["policy","wdl"]` to `prepare()`
+- [ ] Attribution output: `td.get(("attr", "board"))` → 112×8×8 or 64 for heatmap
+- [ ] Use `board.render_heatmap(heatmap)` for visualization (requires `lczerolens[viz]`)
+
+```python
+from lczerolens import LczeroBoard, LczeroModel
+from tdhook.attribution import IntegratedGradients
+from tensordict import TensorDict
+
+model = LczeroModel.from_hf("lczerolens/maia-1100")
+board = LczeroBoard()
+
+def init_attr_targets(td, _):
+    idx = td["policy"].argmax(dim=-1)
+    return TensorDict(out=td["policy"].gather(-1, idx.unsqueeze(-1)).squeeze(-1), batch_size=td.batch_size)
+
+baseline = board.to_input_tensor()
+baseline[:] = 0  # or neutral baseline
+x = model.prepare_boards(board)
+td = TensorDict({"board": x, ("baseline", "board"): baseline.unsqueeze(0)}, batch_size=1)
+
+with IntegratedGradients(init_attr_targets=init_attr_targets).prepare(
+    model, in_keys=["board"], out_keys=["policy", "wdl"]
+) as hooked:
+    td = hooked(td)
+    attr = td.get(("attr", "board"))  # (1, 112, 8, 8) or aggregate to 64
+```
+
+---
+
+## Workflow 4: Probe Concepts on Board Representations
+
+**Goal**: Train probes on representations for classification (e.g. material advantage, threats).
+
+**Checklist**:
+- [ ] Define `Concept` (e.g. `HasMaterialAdvantage`, `HasThreat`, `HasPiece`)
+- [ ] Use `GameData.to_boards(concept=concept)` or `BoardData` with `concept_collate_fn`
+- [ ] For tdhook Probing: `additional_keys=["labels","step_type"]`, `step_type="fit"` / `"predict"`
+- [ ] lc0 model structure: `block0`, `block1`, ... (residual blocks); use regex for layer selection
+
+```python
+from lczerolens import LczeroBoard, LczeroModel
+from lczerolens.concepts import HasMaterialAdvantage, HasPiece
+from lczerolens.data import GameData, BoardData
+
+concept = HasMaterialAdvantage(relative=True)
+# Or: OrBinaryConcept(HasPiece("Q"), HasPiece("R"))
+
+game = GameData.from_dict({"gameid": "1", "moves": "e4 e5 Nf3 Nc6 ..."})
+boards = game.to_boards(n_history=7, concept=concept, output_dict=True)
+# Each dict has "fen", "moves", "label"
+```
+
+---
+
+## Workflow 5: Visualize Heatmaps
+
+**Goal**: Render attribution or policy heatmaps on the chess board.
+
+**Checklist**:
+- [ ] Install `lczerolens[viz]` (matplotlib, graphviz)
+- [ ] Heatmap: `(64,)` or `(8,8)`; use `heatmap_mode`: `"relative_flip"` (default), `"relative_rotation"`, `"absolute"`
+- [ ] `board.render_heatmap(heatmap, save_to="out.svg", ...)` returns SVG or saves files
+
+```python
+from lczerolens import LczeroBoard
+import torch
+
+board = LczeroBoard()
+# heatmap: (64,) or (8,8) from attribution
+heatmap = torch.randn(64)  # example
+svg_board, svg_colorbar = board.render_heatmap(heatmap, normalise="abs")
+# Or: board.render_heatmap(heatmap, save_to="out.svg")
+```
+
+---
+
+## Workflow 6: Evaluate on Puzzles
+
+**Goal**: Score a model on Lichess puzzles.
+
+**Checklist**:
+- [ ] Use `PuzzleData` from dataset; `puzzle.initial_board` for position after first move
+- [ ] Create `ModelSampler` or `PolicySampler` with model
+- [ ] `puzzle.evaluate(sampler)` or `PuzzleData.evaluate_multiple(puzzles, sampler)`
+- [ ] Returns `(score, perplexity)` or `{"score", "perplexity", "normalized_perplexity"}`
+
+```python
+from lczerolens import LczeroBoard, LczeroModel
+from lczerolens.data import PuzzleData
+from lczerolens.sampling import PolicySampler
+
+model = LczeroModel.from_hf("lczerolens/maia-1100")
+sampler = PolicySampler(model=model, use_argmax=True)
+
+puzzle = PuzzleData.from_dict({...})  # from datasets
+score, perplexity = puzzle.evaluate(sampler)
+```
+
+---
+
+## Key API Reference
+
+| Class / Method | Purpose |
+|----------------|---------|
+| `LczeroModel.from_hf(repo_id)` | Load from Hugging Face Hub |
+| `LczeroModel.from_path(path)` | Load .onnx or .pt |
+| `LczeroBoard(fen)` | Create board from FEN |
+| `board.to_input_tensor()` | 112×8×8 input tensor |
+| `board.encode_move(move, us)` | Move → policy index |
+| `board.decode_move(index)` | Policy index → Move |
+| `board.render_heatmap(heatmap)` | Visualize on board |
+| `model.prepare_boards(*boards)` | Batch boards for forward |
+| `PolicyFlow`, `ValueFlow`, `WdlFlow` | Isolate policy/value/wdl heads |
+| `GameData`, `BoardData`, `PuzzleData` | Data for games/boards/puzzles |
+| `ModelSampler`, `PolicySampler`, `MCTSSampler` | Move selection |
+| `Concept`, `HasMaterialAdvantage`, `HasThreat` | Concept labels for probing |
+
+---
+
+## Model Output Keys
+
+| Key | Shape | Description |
+|-----|-------|-------------|
+| `board` | (B, 112, 8, 8) | Input (from TensorDict) |
+| `policy` | (B, 1858) | Move logits |
+| `wdl` | (B, 3) | Win-Draw-Loss probs |
+| `value` | (B,) | Derived from wdl if not native |
+| `mlh` | (B,) | Moves-left head (optional) |
+
+---
+
+## Common Issues & Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| `KeyError` with tdhook | Use `in_keys=["board"]`, `out_keys=["policy","wdl"]` for LczeroModel |
+| Heatmap wrong orientation | Use `heatmap_mode="relative_flip"` (default) for side-to-move view |
+| `ImportError` for viz | `pip install lczerolens[viz]` |
+| Hugging Face load fails | `pip install lczerolens[hf]` |
+| Policy index out of range | Use `board.get_legal_indices()` to mask; policy has 1858 indices |
+| ONNX load error | Ensure `onnx2torch` compatible; try `from_torch_path` if converted |
+
+See [references/api.md](references/api.md) for more details.
+
+---
+
+## Setup & Installation
+
+```bash
+pip install lczerolens
+```
+
+Optional extras:
+```bash
+pip install lczerolens[viz]    # heatmaps, graphviz
+pip install lczerolens[hf]     # Hugging Face Hub
+pip install lczerolens[backends]  # lc0 bindings for conversion
+```
+
+---
+
+## Integration with Interpretability Frameworks
+
+| Framework | Use Case | Key Adapter |
+|-----------|----------|-------------|
+| **tdhook** | Attribution, probing, steering, patching | `in_keys=["board"]`, `out_keys` from model |
+| **captum** | IntegratedGradients, Saliency | Wrap `model.module` or use TensorDict → tensor |
+| **zennit** | LRP, composite rules | Same as captum; board-aligned output |
+| **nnsight** | Activation analysis, remote | `LanguageModel` not applicable; use trace on `model.module` |
+
+---
+
+## References
+
+| File | Contents |
+|------|----------|
+| [references/README.md](references/README.md) | Overview |
+| [references/api.md](references/api.md) | Full API: LczeroModel, LczeroBoard, data, concepts |
+| [references/tutorials.md](references/tutorials.md) | Notebooks and use-case tutorials |
+
+**Official docs**: [lczerolens.readthedocs.io](https://lczerolens.readthedocs.io)

--- a/skills/lczerolens/SKILL.md
+++ b/skills/lczerolens/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Xmaster6y
 license: MIT
 tags: [lczerolens, lc0, Chess, Interpretability, Leela Chess Zero, TensorDict, PyTorch, Heatmaps, Probing, Concepts]
-dependencies: [lczerolens, tensordict>=0.9.1, torch>=2.5.0, python-chess>=1.999]
+dependencies: [lczerolens, tensordict>=0.9.1, torch>=2.5.0, python-chess>=1.999, huggingface-hub>=0.27.1]
 ---
 
 # lczerolens
@@ -207,7 +207,7 @@ score, perplexity = puzzle.evaluate(sampler)
 | `board` | (B, 112, 8, 8) | Input (from TensorDict) |
 | `policy` | (B, 1858) | Move logits |
 | `wdl` | (B, 3) | Win-Draw-Loss probs |
-| `value` | (B,) | Derived from wdl if not native |
+| `value` | (B,) | Native value head (if present); use `ForceValue` to derive from wdl when absent |
 | `mlh` | (B,) | Moves-left head (optional) |
 
 ---

--- a/skills/lczerolens/references/README.md
+++ b/skills/lczerolens/references/README.md
@@ -1,0 +1,19 @@
+# lczerolens Reference Documentation
+
+Deep documentation for the lczerolens skill. See [SKILL.md](../SKILL.md) for the quick reference.
+
+## Quick Links
+
+| Topic | Reference |
+|-------|-----------|
+| Full API (LczeroModel, LczeroBoard, data, concepts) | [api.md](api.md) |
+| Step-by-step use-case tutorials | [tutorials.md](tutorials.md) |
+
+## Official Documentation
+
+- [Home](https://lczerolens.readthedocs.io/)
+- [Getting Started](https://lczerolens.readthedocs.io/en/latest/start.html)
+- [Features](https://lczerolens.readthedocs.io/en/latest/features.html)
+- [Tutorials](https://lczerolens.readthedocs.io/en/latest/tutorials.html)
+- [API Reference](https://lczerolens.readthedocs.io/en/latest/api/index.html)
+- [GitHub](https://github.com/Xmaster6y/lczerolens)

--- a/skills/lczerolens/references/api.md
+++ b/skills/lczerolens/references/api.md
@@ -24,17 +24,17 @@ x = model.prepare_boards(board1, board2, input_encoding=InputEncoding.INPUT_CLAS
 
 ### Flow Variants
 
-- `PolicyFlow(model)`: Isolate policy head only
-- `ValueFlow(model)`: Isolate value head
-- `WdlFlow(model)`: Isolate WDL head
-- `ForceValue(model)`: Force value flow (for MCTS heuristic)
+- `PolicyFlow.from_model(model)`: Isolate policy head only
+- `ValueFlow.from_model(model)`: Isolate value head
+- `WdlFlow.from_model(model)`: Isolate WDL head
+- `ForceValue.from_model(model)`: Force value flow (for MCTS heuristic)
 
 ## LczeroBoard
 
 Subclass of `chess.Board` with lc0-specific encoding.
 
 ```python
-board = LczeroBoard()  # empty
+board = LczeroBoard()
 board = LczeroBoard("r1bqkbnr/pppppppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1")
 
 # Input tensor
@@ -53,7 +53,7 @@ for next_board in board.get_next_legal_boards(n_history=7):
     ...
 
 # Heatmap
-svg_board, svg_colorbar = board.render_heatmap(heatmap, normalise="abs", save_to="out.svg")
+board.render_heatmap(heatmap, normalise="abs", save_to="out.svg")
 ```
 
 ### InputEncoding
@@ -86,7 +86,7 @@ puzzle = PuzzleData.from_dict({...})
 board = puzzle.initial_board  # after first move
 for b, m in puzzle.board_move_generator(all_moves=False):
     ...
-score, perplexity = puzzle.evaluate(sampler)
+metrics = puzzle.evaluate(sampler)
 ```
 
 ## Concepts

--- a/skills/lczerolens/references/api.md
+++ b/skills/lczerolens/references/api.md
@@ -1,0 +1,138 @@
+# lczerolens API Reference
+
+Key classes, usage patterns, and method implementations.
+
+## LczeroModel
+
+TensorDictModule wrapper for lc0 networks. Input key: `board`, output keys: `policy`, `wdl`/`value`, optionally `mlh`.
+
+```python
+# Load
+model = LczeroModel.from_hf("lczerolens/maia-1100")
+model = LczeroModel.from_path("model.onnx")  # or .pt
+model = LczeroModel.from_onnx_path("model.onnx")
+model = LczeroModel.from_torch_path("model.pt")
+
+# Forward
+output = model(board)  # LczeroBoard or (board1, board2)
+output = model(TensorDict({"board": x}, batch_size=B))
+output = model(tensor)  # (B, 112, 8, 8) auto-wrapped
+
+# Prepare boards for batching
+x = model.prepare_boards(board1, board2, input_encoding=InputEncoding.INPUT_CLASSICAL_112_PLANE)
+```
+
+### Flow Variants
+
+- `PolicyFlow(model)`: Isolate policy head only
+- `ValueFlow(model)`: Isolate value head
+- `WdlFlow(model)`: Isolate WDL head
+- `ForceValue(model)`: Force value flow (for MCTS heuristic)
+
+## LczeroBoard
+
+Subclass of `chess.Board` with lc0-specific encoding.
+
+```python
+board = LczeroBoard()  # empty
+board = LczeroBoard("r1bqkbnr/pppppppp/2n5/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R w KQkq - 0 1")
+
+# Input tensor
+tensor = board.to_input_tensor(input_encoding=InputEncoding.INPUT_CLASSICAL_112_PLANE)
+# Shape: (112, 8, 8)
+
+# Move encoding
+idx = LczeroBoard.encode_move(move, board.turn)
+move = board.decode_move(idx)
+
+# Legal indices
+legal = board.get_legal_indices()  # shape (n_legal,)
+
+# Next boards
+for next_board in board.get_next_legal_boards(n_history=7):
+    ...
+
+# Heatmap
+svg_board, svg_colorbar = board.render_heatmap(heatmap, normalise="abs", save_to="out.svg")
+```
+
+### InputEncoding
+
+- `INPUT_CLASSICAL_112_PLANE`: 8 history planes (13 each) + castling + color + halfmove + etc.
+- `INPUT_CLASSICAL_112_PLANE_REPEATED`: Same, repeat last position for empty history
+- `INPUT_CLASSICAL_112_PLANE_NO_HISTORY_REPEATED`: No history, repeat current
+- `INPUT_CLASSICAL_112_PLANE_NO_HISTORY_ZEROS`: No history, zeros
+
+## Data Classes
+
+### GameData
+
+```python
+game = GameData.from_dict({"gameid": "1", "moves": "e4 e5 Nf3 ..."})
+boards = game.to_boards(n_history=7, concept=concept, output_dict=True)
+```
+
+### BoardData
+
+```python
+# From dataset row
+board, labels = BoardData.concept_collate_fn(batch, concept=concept)
+```
+
+### PuzzleData
+
+```python
+puzzle = PuzzleData.from_dict({...})
+board = puzzle.initial_board  # after first move
+for b, m in puzzle.board_move_generator(all_moves=False):
+    ...
+score, perplexity = puzzle.evaluate(sampler)
+```
+
+## Concepts
+
+```python
+# Binary
+HasPiece("Q", relative=True)
+HasMaterialAdvantage(relative=True)
+HasThreat("Q", relative=True)
+HasMateThreat()
+OrBinaryConcept(c1, c2)
+AndBinaryConcept(c1, c2)
+
+# Multiclass
+BestLegalMove(model)
+
+# For probing: concept.compute_label(board), concept.get_dataset_feature()
+```
+
+## Samplers
+
+```python
+ModelSampler(model=model, use_argmax=True)  # alpha*value + beta*mlh + gamma*policy
+PolicySampler(model=model, use_argmax=True)  # policy only
+MCTSSampler(model=model, num_simulations=100)
+RandomSampler()
+
+# Usage
+for board in boards:
+    utility, legal_indices, to_log = next(sampler.get_utilities(iter([board])))
+    move = sampler.choose_move(board, utility, legal_indices)
+```
+
+## SelfPlay
+
+```python
+from lczerolens.sampling import SelfPlay, PolicySampler
+
+sp = SelfPlay(white=PolicySampler(model), black=PolicySampler(model))
+moves, final_board = sp.play(max_moves=100)
+```
+
+## Module Path Resolution (for tdhook)
+
+lc0 models typically have structure:
+- `inputconv`, `block0`, `block1`, ... (residual blocks with `conv1`, `conv2`, SE blocks)
+- Policy/value heads at end
+
+Use regex for layer selection, e.g. `"block[0-9]+\\.conv2$"` for block outputs.

--- a/skills/lczerolens/references/tutorials.md
+++ b/skills/lczerolens/references/tutorials.md
@@ -1,0 +1,24 @@
+# lczerolens Tutorials
+
+Step-by-step tutorials and notebooks.
+
+## Official Notebooks
+
+| Notebook | Description |
+|----------|-------------|
+| [Walkthrough](https://lczerolens.readthedocs.io/en/latest/notebooks/walkthrough.html) | Basic usage: board, model, inference |
+| [Encode Boards](https://lczerolens.readthedocs.io/en/latest/notebooks/features/encode-boards.html) | Input tensor encoding |
+| [Load Models](https://lczerolens.readthedocs.io/en/latest/notebooks/features/load-models.html) | From file, ONNX, Hugging Face |
+| [Move Prediction](https://lczerolens.readthedocs.io/en/latest/notebooks/features/move-prediction.html) | Policy and best move |
+| [Run GPU](https://lczerolens.readthedocs.io/en/latest/notebooks/features/run-models-on-gpu.html) | GPU acceleration |
+| [Evaluate Puzzles](https://lczerolens.readthedocs.io/en/latest/notebooks/features/evaluate-models-on-puzzles.html) | Puzzle evaluation |
+| [Visualise Heatmaps](https://lczerolens.readthedocs.io/en/latest/notebooks/features/visualise-heatmaps.html) | Saliency on board |
+| [Probe Concepts](https://lczerolens.readthedocs.io/en/latest/notebooks/features/probe-concepts.html) | Concept probing |
+| [Framework-Agnostic Interpretability](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/framework-agnostic-interpretability.html) | tdhook, captum, zennit, nnsight
+| [Piece Value Estimation (LRP)](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/piece-value-estimation-using-lrp.html) | LRP with zennit |
+| [Train SAEs](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/train-saes.html) | Sparse autoencoders |
+| [Evidence of Learned Look-Ahead](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/evidence-of-learned-look-ahead.html) | Planning analysis |
+
+## Colab
+
+All notebooks have "Open In Colab" badges. For dev: clone repo and `pip install ./lczerolens`.

--- a/skills/lczerolens/references/tutorials.md
+++ b/skills/lczerolens/references/tutorials.md
@@ -21,4 +21,4 @@ Step-by-step tutorials and notebooks.
 
 ## Colab
 
-All notebooks have "Open In Colab" badges. For dev: clone repo and `pip install ./lczerolens`.
+All notebooks have "Open In Colab" badges. For dev: clone repo, cd into it, then `pip install .` or `uv sync`.

--- a/src/lczerolens/concepts.py
+++ b/src/lczerolens/concepts.py
@@ -289,15 +289,15 @@ class BestLegalMove(MulticlassConcept):
         model: LczeroModel,
     ):
         """Initialize the class."""
-        self.policy_flow = PolicyFlow(model)
+        self.policy_flow = PolicyFlow.from_model(model.module)
 
     def compute_label(
         self,
         board: LczeroBoard,
     ) -> int:
         """Compute the label for a given model and input."""
-        (policy,) = self.policy_flow(board)
-        policy = torch.softmax(policy.squeeze(0), dim=-1)
+        output = self.policy_flow(board)
+        policy = torch.softmax(output["policy"].squeeze(0), dim=-1)
 
         legal_move_indices = [LczeroBoard.encode_move(move, board.turn) for move in board.legal_moves]
         sub_index = policy[legal_move_indices].argmax().item()
@@ -313,7 +313,7 @@ class PieceBestLegalMove(BinaryConcept):
         piece: str,
     ):
         """Initialize the class."""
-        self.policy_flow = PolicyFlow(model)
+        self.policy_flow = PolicyFlow.from_model(model.module)
         self.piece = chess.Piece.from_symbol(piece)
 
     def compute_label(
@@ -321,8 +321,8 @@ class PieceBestLegalMove(BinaryConcept):
         board: LczeroBoard,
     ) -> int:
         """Compute the label for a given model and input."""
-        (policy,) = self.policy_flow(board)
-        policy = torch.softmax(policy.squeeze(0), dim=-1)
+        output = self.policy_flow(board)
+        policy = torch.softmax(output["policy"].squeeze(0), dim=-1)
 
         legal_moves = list(board.legal_moves)
         legal_move_indices = [LczeroBoard.encode_move(move, board.turn) for move in legal_moves]

--- a/src/lczerolens/data.py
+++ b/src/lczerolens/data.py
@@ -517,7 +517,7 @@ class PuzzleData:
         else:
             return metric_inputs_generator()
 
-    def evaluate(self, sampler: Sampler, all_moves: bool = False, **kwargs) -> Tuple[float, Optional[float]]:
+    def evaluate(self, sampler: Sampler, all_moves: bool = False, **kwargs) -> Dict[str, float]:
         """Evaluate this single puzzle using a sampler.
 
         Parameters
@@ -531,8 +531,8 @@ class PuzzleData:
 
         Returns
         -------
-        Tuple[float, Optional[float]]
-            Tuple containing score and perplexity metrics.
+        Dict[str, float]
+            Dictionary containing score, perplexity, and normalized_perplexity metrics.
         """
         return next(iter(self.evaluate_multiple([self], sampler, all_moves, **kwargs)))
 

--- a/tests/unit/test_concepts.py
+++ b/tests/unit/test_concepts.py
@@ -2,6 +2,9 @@
 Test cases for the concept module.
 """
 
+import torch
+from unittest.mock import MagicMock, patch
+
 from lczerolens.concepts import (
     BinaryConcept,
     AndBinaryConcept,
@@ -9,6 +12,8 @@ from lczerolens.concepts import (
     HasPiece,
     HasMaterialAdvantage,
     HasThreat,
+    BestLegalMove,
+    PieceBestLegalMove,
 )
 from lczerolens import LczeroBoard
 
@@ -42,22 +47,18 @@ class TestBinaryConcept:
         """
         Test the relative threat concept.
         """
-        concept = HasThreat("p", relative=True)  # Is an enemy pawn threatened?
+        concept = HasThreat("p", relative=True)
         assert concept.compute_label(LczeroBoard("8/8/8/8/8/8/8/8 w - - 0 1")) == 0
         assert concept.compute_label(LczeroBoard("R7/8/8/8/8/8/p7/8 w - - 0 1")) == 1
         assert concept.compute_label(LczeroBoard("R7/8/8/8/8/8/p7/8 b - - 0 1")) == 0
 
     def test_has_piece_relative_and_absolute(self):
         """Check HasPiece on trivially small boards."""
-        # One white pawn on a2, white to move
         board = LczeroBoard("8/8/8/8/8/8/P7/8 w - - 0 1")
         assert HasPiece("P", relative=True).compute_label(board) == 1
         assert HasPiece("p", relative=True).compute_label(board) == 0
-        # Absolute: white pawn exists regardless of turn
         assert HasPiece("P", relative=False).compute_label(board) == 1
-        # Switch turn
         board = LczeroBoard("8/8/8/8/8/8/P7/8 b - - 0 1")
-        # Relative now refers to black's perspective
         assert HasPiece("P", relative=True).compute_label(board) == 0
         assert HasPiece("p", relative=True).compute_label(board) == 1
 
@@ -82,13 +83,91 @@ class TestBinaryConcept:
 
     def test_has_material_advantage_relative_and_absolute(self):
         """Material advantage on boards with one or two pieces."""
-        # White to move, one white pawn vs lone black king → advantage
         board = LczeroBoard("k7/8/8/8/8/8/P7/7K w - - 0 1")
         assert HasMaterialAdvantage(relative=True).compute_label(board) == 1
         assert HasMaterialAdvantage(relative=False).compute_label(board) == 1
-        # Black to move, same position but turn flips relative perspective
         board = LczeroBoard("k7/8/8/8/8/8/P7/7K b - - 0 1")
-        # Relative: side to move is black (no material) → not advantage
         assert HasMaterialAdvantage(relative=True).compute_label(board) == 0
-        # Absolute advantage for white remains
         assert HasMaterialAdvantage(relative=False).compute_label(board) == 1
+
+
+class TestMoveConcepts:
+    """Test cases for BestLegalMove and PieceBestLegalMove."""
+
+    def test_best_legal_move(self):
+        """Test BestLegalMove returns the index of the policy's best legal move."""
+        board = LczeroBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        legal_indices = [LczeroBoard.encode_move(move, board.turn) for move in board.legal_moves]
+
+        policy = torch.zeros(1858)
+        policy[legal_indices[0]] = 10.0
+        policy[legal_indices[1:]] = -10.0
+
+        mock_policy_flow = MagicMock(return_value={"policy": policy.unsqueeze(0)})
+        mock_model = MagicMock()
+        mock_model.module = MagicMock()
+
+        with patch("lczerolens.concepts.PolicyFlow") as mock_policy_flow_cls:
+            mock_policy_flow_cls.from_model.return_value = mock_policy_flow
+
+            concept = BestLegalMove(mock_model)
+            label = concept.compute_label(board)
+
+        assert label == legal_indices[0]
+        mock_policy_flow_cls.from_model.assert_called_once_with(mock_model.module)
+        mock_policy_flow.assert_called_once_with(board)
+
+    def test_piece_best_legal_move(self):
+        """Test PieceBestLegalMove returns 1 when best move is from the specified piece."""
+        board = LczeroBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        legal_moves = list(board.legal_moves)
+        legal_indices = [LczeroBoard.encode_move(move, board.turn) for move in legal_moves]
+
+        e2e4 = next(m for m in legal_moves if m.uci() == "e2e4")
+        e2e4_idx = LczeroBoard.encode_move(e2e4, board.turn)
+
+        policy = torch.zeros(1858)
+        policy[e2e4_idx] = 10.0
+        for idx in legal_indices:
+            if idx != e2e4_idx:
+                policy[idx] = -10.0
+
+        mock_policy_flow = MagicMock(return_value={"policy": policy.unsqueeze(0)})
+        mock_model = MagicMock()
+        mock_model.module = MagicMock()
+
+        with patch("lczerolens.concepts.PolicyFlow") as mock_policy_flow_cls:
+            mock_policy_flow_cls.from_model.return_value = mock_policy_flow
+
+            concept = PieceBestLegalMove(mock_model, "P")
+            label = concept.compute_label(board)
+
+        assert label == 1
+        mock_policy_flow_cls.from_model.assert_called_once_with(mock_model.module)
+
+    def test_piece_best_legal_move_wrong_piece(self):
+        """Test PieceBestLegalMove returns 0 when best move is not from the specified piece."""
+        board = LczeroBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+        legal_moves = list(board.legal_moves)
+        legal_indices = [LczeroBoard.encode_move(move, board.turn) for move in legal_moves]
+
+        g1f3 = next(m for m in legal_moves if m.uci() == "g1f3")
+        g1f3_idx = LczeroBoard.encode_move(g1f3, board.turn)
+
+        policy = torch.zeros(1858)
+        policy[g1f3_idx] = 10.0
+        for idx in legal_indices:
+            if idx != g1f3_idx:
+                policy[idx] = -10.0
+
+        mock_policy_flow = MagicMock(return_value={"policy": policy.unsqueeze(0)})
+        mock_model = MagicMock()
+        mock_model.module = MagicMock()
+
+        with patch("lczerolens.concepts.PolicyFlow") as mock_policy_flow_cls:
+            mock_policy_flow_cls.from_model.return_value = mock_policy_flow
+
+            concept = PieceBestLegalMove(mock_model, "P")
+            label = concept.compute_label(board)
+
+        assert label == 0

--- a/uv.lock
+++ b/uv.lock
@@ -1546,6 +1546,7 @@ docs = [
     { name = "sphinx-charts" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-design" },
+    { name = "sphinx-llm" },
 ]
 scripts = [
     { name = "loguru" },
@@ -1604,6 +1605,7 @@ docs = [
     { name = "sphinx-charts", specifier = ">=0.2.1" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2" },
     { name = "sphinx-design", specifier = ">=0.6.1" },
+    { name = "sphinx-llm", specifier = ">=0.3.0" },
 ]
 scripts = [
     { name = "loguru", specifier = ">=0.7.3" },
@@ -3897,6 +3899,33 @@ wheels = [
 ]
 
 [[package]]
+name = "sphinx-llm"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sphinx" },
+    { name = "sphinx-markdown-builder" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/69/128ba4687f19974c3a87816482a0fad49b69698bb980c467dd18919d0829/sphinx_llm-0.3.0.tar.gz", hash = "sha256:a994676ee914a5b0415d6607aec9578eb004fc61aaa2b13d27dc8a6729c97791", size = 271045, upload-time = "2026-02-06T09:28:53.047Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/60/153e9130dd8bf49fb5b7a5f89dda851de5aa87eea45e00f93c30d2b52a45/sphinx_llm-0.3.0-py3-none-any.whl", hash = "sha256:4e89d7978d4bc8f755fe89e24e2c0e3a90e60fa6b8740119c9b4a9fd274dff9e", size = 22335, upload-time = "2026-02-06T09:28:51.419Z" },
+]
+
+[[package]]
+name = "sphinx-markdown-builder"
+version = "0.6.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "sphinx" },
+    { name = "tabulate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b3705885d51932e8b62f520388c2772e4952189971727b/sphinx_markdown_builder-0.6.10.tar.gz", hash = "sha256:cd5acf88d52ea0146a712fd557404f10326dff3428a78ba928e59b1727fd4a86", size = 22688, upload-time = "2026-03-11T10:56:57.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
+]
+
+[[package]]
 name = "sphinxcontrib-applehelp"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3986,6 +4015,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What does this PR do?

Key insights about the PR.

## Linked Issues

- Closes #118 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `lczerolens` skill with a quickstart and deep references for interpreting Leela Chess Zero models (load, encode, attribution, heatmaps, puzzles, self-play). Enables `sphinx-llm`, updates tutorial navigation, and disables notebook execution in docs; addresses #118.

- **New Features**
  - Added `skills/lczerolens/SKILL.md` with workflows (load/infer, encoding, attribution/probing, heatmaps, puzzles, self-play) and extras for `tdhook`, `captum`, `zennit`, `nnsight`.
  - Added references and linked new tutorials in docs (automated interpretability, learned look-ahead, LRP piece values, train SAEs) plus a self-play MCTS notebook.

- **Bug Fixes**
  - Fixed concept probes to use `PolicyFlow.from_model(model.module)` and read `"policy"` outputs for best-move and piece-target labels.
  - `PuzzleData.evaluate` now returns a dict with `score`, `perplexity`, and `normalized_perplexity`.
  - Docs: corrected a heading underline, set `nbsphinx_execute = "never"`, and kept AutoAPI files to avoid RTD build issues.

<sup>Written for commit 32abfd2e05080bc798c00fcefd5ef46581871e6b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

