### PR TITLE
Define lc0 interoperability and chess-decision scope

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,3 +42,12 @@ just docs
 ## Branches
 
 Make a branch before opening a pull request to `main`.
+
+## Scope gate
+
+Before proposing new public API, check it against the [scope and compatibility
+policy](docs/source/scope.rst). Core changes must either preserve the lc0 model
+interoperability contract or add chess-domain decision evidence. Hooks,
+attribution, probing, SAE/transcoder, and coaching abstractions belong in
+downstream integrations unless a later scope decision explicitly changes this
+boundary.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 ![publish](https://github.com/Xmaster6y/lczerolens/actions/workflows/publish.yml/badge.svg)
 [![docs](https://readthedocs.org/projects/lczerolens/badge/?version=latest)](https://lczerolens.readthedocs.io/en/latest/?badge=latest)
 
-Leela Chess Zero (lc0) Lens (`lczerolens`): a set of utilities to make interpretability easy and framework-agnostic (PyTorch): use it with `tdhook`, `captum`, `zennit`, or `nnsight`.
+Leela Chess Zero (lc0) Lens (`lczerolens`) makes lc0-family models portable and operable in PyTorch, then expresses their evaluator and search behavior as chess-domain evidence. It provides the model and chess-analysis boundary; interpretability methods remain external integrations. See the [scope and compatibility policy](https://lczerolens.readthedocs.io/en/latest/scope.html).
 
 ## Getting Started
 
@@ -54,9 +54,9 @@ best_move_idx = output["policy"].argmax()
 print(board.decode_move(best_move_idx))
 ```
 
-### Framework-Agnostic Interpretability
+### External Interpretability Integrations
 
-Use `lczerolens` with your preferred PyTorch interpretability framework (`tdhook`, `captum`, `zennit`, `nnsight`). More examples in the [framework-agnostic interpretability notebook](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/framework-agnostic-interpretability.html).
+Use `lczerolens` with your preferred PyTorch interpretability framework (`tdhook`, `captum`, `zennit`, `nnsight`). These packages are optional examples, not lczerolens abstractions or dependencies of its core evaluator contract. More examples are in the [framework-agnostic interpretability notebook](https://lczerolens.readthedocs.io/en/latest/notebooks/tutorials/framework-agnostic-interpretability.html).
 
 ```python
 from lczerolens import LczeroBoard, LczeroModel

--- a/README.md
+++ b/README.md
@@ -50,8 +50,11 @@ model = LczeroModel.from_hf("lczerolens/maia-1100")
 board = LczeroBoard()
 
 output = model(board)
-best_move_idx = output["policy"].argmax()
-print(board.decode_move(best_move_idx))
+policy = output["policy"].squeeze(0)
+legal_indices = board.get_legal_indices()
+best_legal_offset = policy[legal_indices].argmax()
+best_move_idx = legal_indices[best_legal_offset]
+print(board.decode_move(best_move_idx.item()))
 ```
 
 ### External Interpretability Integrations

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,7 @@ lczerolens
     :hidden:
 
     start
+    scope
     features
     tutorials
     api/index
@@ -33,10 +34,10 @@ lczerolens
 
         .. div:: sd-fs-4 sd-font-weight-bold sd-my-0 sub-bot image-container
 
-            Interpretability for lc0 networks
+            lc0 interoperability and chess-decision analysis
 
-        **lczerolens** focuses on interpretability for lc0 networks, with utilities to load/run models and render heatmaps.
-        It is framework-agnostic (PyTorch), so you can use it with `tdhook`, `captum`, `zennit`, or `nnsight`.
+        **lczerolens** makes lc0-family models operable in PyTorch and turns their evaluator and search behavior into chess-domain evidence.
+        Interpretability frameworks such as `tdhook`, `captum`, `zennit`, and `nnsight` integrate at this boundary; they are not core abstractions.
 
         .. div:: button-group
 

--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -15,41 +15,45 @@ variations, and search decisions.
 Supported use cases
 -------------------
 
-lczerolens supports:
+Current v0.4 capabilities are:
 
 * loading or converting lc0-family weights and evaluating one position or a
   batch in PyTorch;
 * encoding positions and mapping policy indices to legal chess moves;
 * consuming a standardized policy, WDL, value, and MLH evaluator result;
-* recording and comparing position facts, moves, variations, counterfactual
-  positions, and search traces; and
 * passing an evaluator through arbitrary external instrumentation while
   retaining the same input/output contract.
+
+The planned in-scope public surface will add chess-domain evidence for position
+facts, moves, variations, counterfactual positions, and search traces and
+comparisons. Those facilities do not yet have a counterfactual API or a
+search-trace schema in v0.4; this policy defines their ownership before they are
+introduced.
 
 Evaluator contract
 ------------------
 
-The model boundary is ``LczeroBoard`` positions in and a ``TensorDict`` out.
-The output has policy logits over the fixed lc0 vocabulary and WDL probabilities
-when the network supplies them; value and MLH are exposed when supplied or
-derived by an explicit adapter such as ``ForceValue``. Batching, device
-movement, and legal-policy masking preserve that contract. Consumers must mask
-policy values with the board's legal indices before interpreting them as move
-choices.
+Conceptually, the chess boundary is an ``LczeroBoard`` position in and a
+``TensorDict`` evaluator result out. At runtime, ``LczeroModel.forward()`` also
+accepts an iterable of boards, a 3D or 4D board tensor, or a ``TensorDict``.
+The output contains raw policy values over the fixed 1858-entry lc0 vocabulary
+and WDL probabilities when the network supplies them; value and MLH are exposed
+when supplied or derived by an explicit adapter such as ``ForceValue``.
+Batching and device movement preserve this contract. Legal masking is a
+downstream operation: the wrapper returns raw policy values, and consumers must
+select the board's legal indices before interpreting a move choice.
 
 Architecture boundary
 ---------------------
 
 .. code-block:: text
 
-   python-chess                      external interpretability tools
-   rules, FEN, legal moves           hooks, patches, probes, attribution
-          |                                          |
-          v                                          | instruments only
-   LczeroBoard -- encoding / move vocabulary --------+
-          |
-          v
-   lc0 adapters -- conversion, loading, TensorDict batching
+   python-chess                         external interpretability tools
+   rules, FEN, legal moves              hooks, patches, probes, attribution
+          |                                            |
+          v                                            | wrap or instrument
+   LczeroBoard -- encoding / move vocabulary --> lc0 adapters / PyTorch evaluator
+                                              conversion, loading, TensorDict batching
           |
           v
    evaluator contract -- policy / WDL / value / MLH

--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -1,0 +1,158 @@
+Scope and compatibility policy
+==============================
+
+Mission
+-------
+
+**lczerolens makes lc0-family models portable and operable in PyTorch, then
+expresses their evaluator and search behavior as chess-domain evidence.**
+
+The two halves are mutually necessary: a chess analysis cannot be reproduced or
+compared without a reliable lc0 evaluator contract, and model outputs become
+useful chess evidence only when they are related to positions, legal moves,
+variations, and search decisions.
+
+Supported use cases
+-------------------
+
+lczerolens supports:
+
+* loading or converting lc0-family weights and evaluating one position or a
+  batch in PyTorch;
+* encoding positions and mapping policy indices to legal chess moves;
+* consuming a standardized policy, WDL, value, and MLH evaluator result;
+* recording and comparing position facts, moves, variations, counterfactual
+  positions, and search traces; and
+* passing an evaluator through arbitrary external instrumentation while
+  retaining the same input/output contract.
+
+Evaluator contract
+------------------
+
+The model boundary is ``LczeroBoard`` positions in and a ``TensorDict`` out.
+The output has policy logits over the fixed lc0 vocabulary and WDL probabilities
+when the network supplies them; value and MLH are exposed when supplied or
+derived by an explicit adapter such as ``ForceValue``. Batching, device
+movement, and legal-policy masking preserve that contract. Consumers must mask
+policy values with the board's legal indices before interpreting them as move
+choices.
+
+Architecture boundary
+---------------------
+
+.. code-block:: text
+
+   python-chess                      external interpretability tools
+   rules, FEN, legal moves           hooks, patches, probes, attribution
+          |                                          |
+          v                                          | instruments only
+   LczeroBoard -- encoding / move vocabulary --------+
+          |
+          v
+   lc0 adapters -- conversion, loading, TensorDict batching
+          |
+          v
+   evaluator contract -- policy / WDL / value / MLH
+          |
+          +-----------------------------+
+          |                             |
+          v                             v
+   chess-semantic analysis          search traces and comparisons
+   position facts, move/variation,  evaluator-guided MCTS evidence
+   counterfactual evidence
+
+``python-chess`` owns chess rules. External tools own neural-method semantics.
+lczerolens owns the arrows between them: lc0 interoperability, the stable
+evaluator result, and chess-specific decision evidence. Search is an analysis
+and comparison facility, not a production engine.
+
+Non-goals
+---------
+
+The core API does not own chess rules, production-engine search, generic hook
+or patch systems, attribution algorithms, probing, SAE/transcoder methods, or
+natural-language coaching. Examples may demonstrate external tools, but no
+implementation-specific interpretability method is required by the core API.
+
+Public-surface disposition
+--------------------------
+
+The table covers every current importable package module and its public symbols.
+``Retain`` means supported as part of the stated boundary; ``refocus`` means the
+symbol stays available but future changes must serve that boundary. ``Internalize``
+means keep it implementation-facing rather than adding compatibility commitments;
+``deprecate`` means do not extend it and replace it in a later, separately
+announced compatibility release.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 14 38 12 36
+
+   * - Module
+     - Symbols
+     - Disposition
+     - Rationale
+   * - ``__init__``
+     - ``LczeroBoard``, ``LczeroModel``
+     - Retain
+     - Small stable entry point for positions and evaluators.
+   * - ``board``
+     - ``InputEncoding``, ``LczeroBoard``
+     - Retain
+     - lc0 encoding, legal moves, and policy vocabulary bridge.
+   * - ``constants``
+     - Policy-index and encoding constants
+     - Internalize
+     - Authoritative substrate; avoid promising incidental names.
+   * - ``model``
+     - ``LczeroModel``, ``ForceValue``; ``Flow``, ``PolicyFlow``,
+       ``ValueFlow``, ``WdlFlow``, ``MlhFlow``
+     - Retain; refocus flows
+     - Preserve evaluator loading and output adapters; do not make a hook API.
+   * - ``backends``
+     - ``generic_command``, ``describenet``, ``convert_to_onnx``,
+       ``convert_to_leela``, ``board_from_backend``,
+       ``prediction_from_backend``, ``moves_with_castling_swap``
+     - Refocus
+     - lc0 conversion/backend interoperation; low-level helpers remain subordinate to model adapters.
+   * - ``data``
+     - ``columns_to_rows``, ``rows_to_columns``, ``GameData``,
+       ``BoardData``, ``PuzzleData``
+     - Refocus
+     - Position/game/puzzle evidence adapters, not a general data platform.
+   * - ``concepts``
+     - ``Concept``, ``BinaryConcept``, ``NullConcept``, ``OrBinaryConcept``,
+       ``AndBinaryConcept``, ``MulticlassConcept``, ``ContinuousConcept``,
+       ``HasPiece``, ``HasMaterialAdvantage``, ``BestLegalMove``,
+       ``PieceBestLegalMove``, ``HasThreat``, ``HasMateThreat``
+     - Refocus
+     - Chess-semantic position and move facts; no generic probing framework.
+   * - ``sampling``
+     - ``Sampler``, ``RandomSampler``, ``ModelSampler``, ``PolicySampler``,
+       ``MCTSSampler``, ``SelfPlay``
+     - Refocus
+     - Evaluation-driven move and self-play comparisons, not engine serving.
+   * - ``search``
+     - ``Heuristic``, ``RandomHeuristic``, ``MaterialHeuristic``,
+       ``ModelHeuristic``, ``Node``, ``MCTS``
+     - Refocus
+     - Search traces and comparisons supporting decision evidence.
+
+Compatibility policy
+--------------------
+
+The top-level ``LczeroBoard`` and ``LczeroModel`` imports, the board encoding
+and policy-index mapping, and the evaluator field meanings are the compatibility
+core. A compatible release must preserve their documented semantics or provide a
+deprecation path and migration note. Refocused modules remain importable during
+the 0.x series but may receive narrower contracts; any removal or behavior break
+requires a deprecation warning in one minor release and release notes describing
+the replacement. Internal implementation names may change without that promise.
+
+New feature gate
+----------------
+
+Before adding public surface, a proposal must identify which supported use case
+it advances, state its evaluator-contract effect, and show why it belongs to
+lc0 interoperability or chess-decision evidence. If it instead owns a generic
+interpretability technique, it belongs in an external integration or example.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,9 +1,12 @@
 Getting Started
 ===============
 
-**lczerolens** is a package for running interpretability methods on lc0 models.
-It is designed to be easy to use and to work with the most common interpretability
-techniques. It is framework-agnostic (as long as you use PyTorch): you can pair it with ``tdhook``, ``captum``, ``zennit``, or ``nnsight``.
+**lczerolens** makes lc0-family models portable and operable in PyTorch, then
+expresses their evaluator and search behavior as chess-domain evidence. It owns
+the model and chess-analysis boundary, not a neural-interpretability method.
+Tools such as ``tdhook``, ``captum``, ``zennit``, and ``nnsight`` can instrument
+that boundary without lczerolens depending on or abstracting over them. See
+:doc:`scope` for the supported surface and compatibility policy.
 
 .. _installation:
 


### PR DESCRIPTION
## Summary

- define the canonical lc0 interoperability and chess-decision analysis mission
- add the evaluator contract, architecture boundary, non-goals, public-surface disposition, and compatibility policy
- align README, docs entry points, and contributor guidance with the boundary

## Why

The package previously described itself as a home for framework-agnostic interpretability. This makes ownership explicit: lczerolens owns lc0 model interoperability and chess-domain decision evidence, while external tools own hooks, probes, patches, and attribution methods.

## Validation

- `git diff --check`
- `uv run --group docs sphinx-build -b html docs/source /private/tmp/lczerolens-issue-129-docs-final` (succeeds; existing project warnings remain)

Closes #129