### PR TITLE
Harden lc0 evaluator interoperability contract

### DIFF
--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -42,6 +42,22 @@ when supplied or derived by an explicit adapter such as ``ForceValue``.
 Batching and device movement preserve this contract. Legal masking is a
 downstream operation: the wrapper returns raw policy values, and consumers must
 select the board's legal indices before interpreting a move choice.
+``LczeroBoard.get_legal_policy(policy)`` performs that selection and softmax
+normalization for one policy vector; it rejects terminal positions, malformed
+vectors, and non-finite legal logits rather than returning an invalid
+distribution.
+
+Model-format compatibility
+--------------------------
+
+``LczeroModel.from_path`` supports ``.onnx`` files through ``onnx2torch`` and
+serialized ``.pt`` ``torch.nn.Module`` objects. Official lc0 weights are
+converted with the optional native backend's ``leela2onnx`` command, then loaded
+from the resulting ONNX file. Native bindings are a conversion and conformance
+oracle only; ordinary PyTorch inference and unit tests do not require them.
+Arbitrary PyTorch modules can be wrapped with ``LczeroModel(module, out_keys)``;
+automatic head discovery is reserved for converted lc0 graphs and reports how
+to provide explicit keys when that structure is unavailable.
 
 Architecture boundary
 ---------------------

--- a/src/lczerolens/board.py
+++ b/src/lczerolens/board.py
@@ -257,6 +257,31 @@ class LczeroBoard(chess.Board):
         us = self.turn
         return torch.tensor([self.encode_move(move, us) for move in self.legal_moves])
 
+    def get_legal_policy(self, policy: torch.Tensor) -> torch.Tensor:
+        """Return normalized probabilities for this position's legal moves.
+
+        ``policy`` is the evaluator's raw lc0 policy logits.  The returned
+        tensor is ordered like :meth:`get_legal_indices`, rather than the full
+        1858-entry vocabulary, so its entries always sum to one.
+
+        Raises
+        ------
+        ValueError
+            If ``policy`` is not a single lc0 policy vector, has non-finite
+            legal logits, or the position has no legal moves.
+        """
+        if policy.ndim != 1 or policy.shape[0] != len(POLICY_INDEX):
+            raise ValueError(
+                f"Expected one policy vector with {len(POLICY_INDEX)} entries, got shape {tuple(policy.shape)}."
+            )
+        legal_indices = self.get_legal_indices().to(policy.device)
+        if legal_indices.numel() == 0:
+            raise ValueError("Cannot normalize a legal policy for a position with no legal moves.")
+        legal_logits = policy.gather(0, legal_indices)
+        if not torch.isfinite(legal_logits).all():
+            raise ValueError("Cannot normalize a legal policy with non-finite legal logits.")
+        return torch.softmax(legal_logits, dim=0)
+
     def get_next_legal_boards(
         self,
         n_history: int = 7,

--- a/src/lczerolens/board.py
+++ b/src/lczerolens/board.py
@@ -274,9 +274,9 @@ class LczeroBoard(chess.Board):
             raise ValueError(
                 f"Expected one policy vector with {len(POLICY_INDEX)} entries, got shape {tuple(policy.shape)}."
             )
+        if self.is_game_over():
+            raise ValueError("Cannot normalize a legal policy for a terminal position.")
         legal_indices = self.get_legal_indices().to(policy.device)
-        if legal_indices.numel() == 0:
-            raise ValueError("Cannot normalize a legal policy for a position with no legal moves.")
         legal_logits = policy.gather(0, legal_indices)
         if not torch.isfinite(legal_logits).all():
             raise ValueError("Cannot normalize a legal policy with non-finite legal logits.")

--- a/src/lczerolens/model.py
+++ b/src/lczerolens/model.py
@@ -64,9 +64,11 @@ class LczeroModel(TensorDictModule):
         torch.Tensor
             The prepared boards.
         """
+        if not boards:
+            raise ValueError("Expected at least one LczeroBoard.")
         for board in boards:
             if not isinstance(board, LczeroBoard):
-                raise ValueError(f"Got invalid input type {type(board)}.")
+                raise TypeError(f"Got invalid board type {type(board)}. Expected LczeroBoard.")
 
         tensor_list = [board.to_input_tensor(input_encoding=input_encoding).unsqueeze(0) for board in boards]
         batched_tensor = torch.cat(tensor_list, dim=0)
@@ -105,12 +107,16 @@ class LczeroModel(TensorDictModule):
                 inputs = inputs.unsqueeze(0)
             elif len(inputs.shape) != 4:
                 raise ValueError(f"Expected 3D or 4D tensor, got {inputs.shape}.")
+            inputs = inputs.to(self.device)
             inputs = TensorDict({"board": inputs}, batch_size=inputs.shape[0])
         return super().forward(inputs, **kwargs)
 
     def _call_module(self, tensors: Sequence[torch.Tensor], **kwargs: Any) -> Sequence[torch.Tensor]:
         out = super()._call_module(tensors, **kwargs)
-        return tuple(out)
+        # TensorDictModule expects one value per output key.  Converted lc0
+        # graphs return a tuple, while transparent PyTorch wrappers often
+        # return a single tensor.
+        return (out,) if isinstance(out, torch.Tensor) else tuple(out)
 
     @classmethod
     def from_model(cls, model: nn.Module, **kwargs) -> "LczeroModel":
@@ -182,8 +188,7 @@ class LczeroModel(TensorDictModule):
         if not os.path.exists(onnx_model_path):
             raise FileNotFoundError(f"Model path {onnx_model_path} does not exist.")
         try:
-            if check:
-                onnx_model = safe_shape_inference(onnx_model_path)
+            onnx_model = safe_shape_inference(onnx_model_path) if check else onnx_model_path
             onnx_torch_model = convert(onnx_model)
             return cls.from_model(onnx_torch_model, **kwargs)
         except Exception as e:
@@ -319,6 +324,11 @@ class LczeroModel(TensorDictModule):
         List[str]
             The output names of the model.
         """
+        if not hasattr(model, "graph"):
+            raise ValueError(
+                "Cannot infer evaluator heads from this PyTorch module. "
+                "Pass explicit out_keys to LczeroModel(...) or load an lc0 ONNX model."
+            )
         output_node = list(model.graph.nodes)[-1]
         return [n.name.replace("output_", "") for n in output_node.all_input_nodes]
 

--- a/tests/unit/test_board.py
+++ b/tests/unit/test_board.py
@@ -201,9 +201,16 @@ class TestLegalPolicy:
         with pytest.raises(ValueError, match="policy|logits"):
             LczeroBoard().get_legal_policy(policy)
 
-    def test_rejects_terminal_position(self):
-        board = LczeroBoard("7k/6Q1/6K1/8/8/8/8/8 b - - 0 1")
-        with pytest.raises(ValueError, match="no legal moves"):
+    @pytest.mark.parametrize(
+        "fen",
+        [
+            "7k/6Q1/6K1/8/8/8/8/8 b - - 0 1",  # checkmate: no legal moves
+            "8/8/8/8/8/8/8/K6k w - - 0 1",  # insufficient material: legal moves remain
+        ],
+    )
+    def test_rejects_terminal_position(self, fen):
+        board = LczeroBoard(fen)
+        with pytest.raises(ValueError, match="terminal position"):
             board.get_legal_policy(torch.zeros(1858))
 
 

--- a/tests/unit/test_board.py
+++ b/tests/unit/test_board.py
@@ -5,6 +5,7 @@ Tests for the board.
 from typing import List, Tuple
 import pytest
 import chess
+import torch
 from lczero.backends import GameState
 
 from lczerolens import backends as lczero_utils
@@ -176,6 +177,34 @@ class TestStability:
             decoded_move = board.decode_move(encoded_move)
             assert move == decoded_move
             us, them = them, us
+
+
+class TestLegalPolicy:
+    def test_masks_then_normalizes_legal_logits(self):
+        board = LczeroBoard()
+        legal_indices = board.get_legal_indices()
+        policy = torch.full((1858,), -100.0)
+        policy[legal_indices[0]] = 0.0
+        policy[legal_indices[1]] = 1.0
+
+        legal_policy = board.get_legal_policy(policy)
+
+        assert legal_policy.shape == legal_indices.shape
+        assert torch.allclose(legal_policy.sum(), torch.tensor(1.0))
+        assert torch.allclose(legal_policy[:2], torch.softmax(torch.tensor([0.0, 1.0]), dim=0))
+
+    @pytest.mark.parametrize(
+        "policy",
+        [torch.zeros(1857), torch.zeros((1, 1858)), torch.full((1858,), float("nan"))],
+    )
+    def test_rejects_malformed_or_nonfinite_policy(self, policy):
+        with pytest.raises(ValueError, match="policy|logits"):
+            LczeroBoard().get_legal_policy(policy)
+
+    def test_rejects_terminal_position(self):
+        board = LczeroBoard("7k/6Q1/6K1/8/8/8/8/8 b - - 0 1")
+        with pytest.raises(ValueError, match="no legal moves"):
+            board.get_legal_policy(torch.zeros(1858))
 
 
 @pytest.mark.backends

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -2,9 +2,11 @@
 
 import pytest
 import torch
+import chess
 from lczero.backends import GameState
 from huggingface_hub import delete_repo
 from torch import nn
+from tensordict import TensorDict
 
 from lczerolens.model import LczeroBoard, PolicyFlow, ValueFlow, WdlFlow, MlhFlow, ForceValue, LczeroModel
 from lczerolens import backends as lczero_utils
@@ -61,6 +63,37 @@ class TestModel:
 
 
 class TestManageModels:
+    def test_prepare_boards_rejects_empty_or_invalid_input(self):
+        model = LczeroModel(nn.Identity(), out_keys=["output"])
+        with pytest.raises(ValueError, match="at least one"):
+            model.prepare_boards()
+        with pytest.raises(TypeError, match="Expected LczeroBoard"):
+            model.prepare_boards(chess.Board())
+
+    def test_raw_tensor_is_batched_and_moved_to_evaluator_device(self):
+        model = LczeroModel(nn.Identity(), out_keys=["output"])
+        output = model(torch.zeros((112, 8, 8)))
+        assert output["output"].shape == (1, 112, 8, 8)
+        assert output["output"].device == model.device
+
+    def test_tensordict_input_remains_transparent(self):
+        model = LczeroModel(nn.Identity(), out_keys=["output"])
+        inputs = TensorDict({"board": torch.zeros((1, 112, 8, 8))}, batch_size=1)
+        output = model(inputs)
+        assert output["output"].shape == (1, 112, 8, 8)
+
+    def test_from_model_requires_explicit_keys_for_plain_modules(self):
+        with pytest.raises(ValueError, match="explicit out_keys"):
+            LczeroModel.from_model(nn.Identity())
+
+    def test_onnx_loading_without_shape_check_passes_the_path(self, monkeypatch, tmp_path):
+        path = tmp_path / "model.onnx"
+        path.touch()
+        converted = nn.Identity()
+        monkeypatch.setattr("lczerolens.model.convert", lambda value: converted)
+        monkeypatch.setattr(LczeroModel, "from_model", classmethod(lambda cls, model, **_: model))
+        assert LczeroModel.from_onnx_path(str(path), check=False) is converted
+
     def test_model_from_hf_is_hermetic(self, monkeypatch):
         """The Hub adapter forwards its download result without contacting the network."""
         import huggingface_hub


### PR DESCRIPTION
## Summary

Closes #130.

- normalize legal policy probabilities through one board-level contract with explicit invalid and terminal-position failures
- harden evaluator inputs, raw-tensor device movement, transparent single-tensor wrappers, unchecked ONNX loading, and head-discovery diagnostics
- document the evaluator behavior and model-format compatibility path

## Validation

- `uv run --group dev pytest tests/unit -q` (105 passed)
- `uv run --group dev pre-commit run --files docs/source/scope.rst src/lczerolens/board.py src/lczerolens/model.py tests/unit/test_board.py tests/unit/test_model.py`