### PR TITLE
Define search ownership and trace schema

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ lczerolens
 
     start
     scope
+    search
     features
     tutorials
     api/index

--- a/docs/source/scope.rst
+++ b/docs/source/scope.rst
@@ -26,9 +26,8 @@ Current v0.4 capabilities are:
 
 The planned in-scope public surface will add chess-domain evidence for position
 facts, moves, variations, counterfactual positions, and search traces and
-comparisons. Those facilities do not yet have a counterfactual API or a
-search-trace schema in v0.4; this policy defines their ownership before they are
-introduced.
+comparisons. Search records follow the capability-aware schema in
+:doc:`search`; counterfactual facilities do not yet have a public API in v0.4.
 
 Evaluator contract
 ------------------
@@ -157,6 +156,10 @@ announced compatibility release.
        ``ModelHeuristic``, ``Node``, ``MCTS``
      - Refocus
      - Search traces and comparisons supporting decision evidence.
+   * - ``search_trace``
+     - Typed provenance, budget, snapshot, edge-statistic, event, and capability records
+     - Retain
+     - Engine-independent public evidence boundary for reference and production search adapters.
 
 Compatibility policy
 --------------------

--- a/docs/source/search.rst
+++ b/docs/source/search.rst
@@ -37,7 +37,9 @@ The schema uses stable UCI move strings at adapter boundaries. FEN identifies
 the root position, including side to move and clocks. Provenance records source,
 engine/version, network identity/checksum when available, and source-specific
 parameters. A :class:`~lczerolens.search_trace.SearchBudget` distinguishes the
-requested budget from the observed budget and states its unit.
+requested budget from the observed budget and states its unit. Node, visit,
+simulation, and depth budgets are non-negative integers; time budgets may be
+fractional milliseconds.
 
 Root snapshots contain an optional position evaluation, selected action, and
 root-action records. A principal variation is only the move sequence reported
@@ -104,7 +106,8 @@ Capabilities are ordered promises:
 
 ``root_result``
   A root evaluation and/or selected move is available. Action details may be
-  absent.
+  absent. A trace must contain at least one snapshot with one of these root
+  fields, though an intermediate snapshot may contain only action statistics.
 
 ``root_action_stats``
   The producer exposed the legal root action collection and available P/N/W/Q/U

--- a/docs/source/search.rst
+++ b/docs/source/search.rst
@@ -70,7 +70,8 @@ scalar value, WDL, or both; one is not silently derived from the other.
 For an edge from a node to a legal action:
 
 * ``P`` (``prior``) is the normalized probability assigned to that action at
-  expansion. It is non-negative and legal-action priors sum to one.
+  expansion. It is non-negative; when every exposed root action has ``P``,
+  those priors sum to one.
 * ``N`` (``visits``) is the number of completed traversals backed up through
   that edge at the time of the record.
 * ``W`` (``total_value``) is the sum of backed-up scalar values in the edge's
@@ -118,7 +119,10 @@ Capabilities are ordered promises:
 
 ``replayable``
   Every event also contains the backup and pre/post root state required for an
-  independent replayer to reconstruct the emitted root statistics.
+  independent replayer to reconstruct the emitted root statistics. Each state
+  is non-empty, contains exactly one edge transition matching a recorded
+  backup, chains from the preceding event, and the final state equals the final
+  root snapshot.
 
 Consumers call :meth:`~lczerolens.search_trace.SearchTrace.supports` or
 :meth:`~lczerolens.search_trace.SearchTrace.require` before making a claim.

--- a/docs/source/search.rst
+++ b/docs/source/search.rst
@@ -1,0 +1,198 @@
+Search ownership and trace contract
+===================================
+
+Status
+------
+
+This page is the architecture decision for the search surface introduced by
+issue #131. It fixes the contract that the deterministic reference search and
+the lc0 adapter must implement; those implementations belong to follow-up
+issues #140 and #141.
+
+Decision and ownership
+----------------------
+
+Production-strength search belongs to lc0 or another chess engine.
+``lczerolens`` may launch or attach to such an engine and translate evidence it
+actually exposes, but it does not own engine strength, time management, tree
+reuse, batching, collision handling, pruning, transpositions, or lc0 fidelity.
+
+``lczerolens`` does own an engine-independent trace vocabulary and a small,
+deterministic neural-MCTS reference implementation. The reference search exists
+for auditability, replay, hermetic tests, and research instrumentation. It is
+not a production engine and must not be presented as numerically or
+behaviorally equivalent to lc0.
+
+Public schema
+-------------
+
+The typed records live in :mod:`lczerolens.search_trace`. A
+:class:`~lczerolens.search_trace.SearchTrace` contains root position identity,
+producer provenance, one or more root snapshots, an advertised capability, and
+optional per-simulation events. ``None`` means a field was unavailable from the
+source. Adapters must not calculate a plausible value merely to fill an absent
+field.
+
+The schema uses stable UCI move strings at adapter boundaries. FEN identifies
+the root position, including side to move and clocks. Provenance records source,
+engine/version, network identity/checksum when available, and source-specific
+parameters. A :class:`~lczerolens.search_trace.SearchBudget` distinguishes the
+requested budget from the observed budget and states its unit.
+
+Root snapshots contain an optional position evaluation, selected action, and
+root-action records. A principal variation is only the move sequence reported
+by the producer; an adapter must not extend it. Reference-search events contain
+the selected node/edge path, leaf record, optional expansion, backups, and
+pre/post root edge state. Stable string node and event identifiers are assigned
+by the producer. ``full_events`` means the emitted simulation events are
+available; it does not mean every private engine node or a complete final tree
+was exported.
+
+Statistic and value semantics
+-----------------------------
+
+Every scalar evaluation, WDL record, and edge-statistics record names its
+:class:`~lczerolens.search_trace.ValuePerspective`. ``root_player`` means the
+side to move in the trace's root FEN; ``side_to_move`` means the side to move at
+the position where the record occurs. ``white`` and ``black`` are absolute.
+Comparisons and backups must first put values in the same perspective. The
+reference search alternates the sign once for every parent/child ply. A terminal
+win, draw, or loss is valued ``+1``, ``0``, or ``-1`` for the stated
+perspective.
+
+WDL is ordered ``(win, draw, loss)`` for its stated perspective, contains
+probabilities that sum to one, and converts to a scalar as
+``win + draw_score * draw - loss``. The default draw score is zero. lc0's
+reported ``WL = win - loss`` and ``D = draw`` convert exactly as
+``win = (1 - D + WL) / 2`` and ``loss = (1 - D - WL) / 2``. A source may provide
+scalar value, WDL, or both; one is not silently derived from the other.
+
+For an edge from a node to a legal action:
+
+* ``P`` (``prior``) is the normalized probability assigned to that action at
+  expansion. It is non-negative and legal-action priors sum to one.
+* ``N`` (``visits``) is the number of completed traversals backed up through
+  that edge at the time of the record.
+* ``W`` (``total_value``) is the sum of backed-up scalar values in the edge's
+  stated perspective.
+* ``Q`` (``mean_value``) is ``W / N``. Its convention is exactly zero when
+  ``N == 0``.
+* ``U`` (``exploration``) is the exploration contribution reported by the
+  producer at selection time. Its formula is source-specific, so adapters
+  retain it only when exposed and never recompute it as if all engines used the
+  reference PUCT formula.
+
+A leaf evaluation is the value first available at the selected leaf, before
+sign-changing backups. Reference events additionally record evaluator dtype,
+the evaluator and search devices, and legal policy logits when an evaluator was
+called. A :class:`~lczerolens.search_trace.BackupUpdate` records the signed value
+used at that edge plus its pre/post statistics. The reference implementation in
+#140 must enforce ``N_post = N_pre + 1``, ``W_post = W_pre + signed_value``, and
+``Q_post = W_post / N_post``.
+
+The selected root action is recorded separately from its statistics. Its rule,
+temperature when applicable, and tie-break are mandatory. The deterministic
+reference search uses maximum visit count at temperature zero and stable UCI
+lexicographic order for exact ties. Engine adapters state ``engine-defined``
+when the engine does not expose a more precise tie rule.
+
+Capabilities
+------------
+
+Capabilities are ordered promises:
+
+``root_result``
+  A root evaluation and/or selected move is available. Action details may be
+  absent.
+
+``root_action_stats``
+  The producer exposed the legal root action collection and available P/N/W/Q/U
+  fields. Individual statistics remain ``None`` if the source omitted them.
+
+``root_snapshots``
+  Budget-labelled root action statistics are available at one or more points.
+
+``full_events``
+  Append-only per-simulation path, leaf, expansion, and backup event records are
+  available. This is still not a claim of private full-tree access.
+
+``replayable``
+  Every event also contains the backup and pre/post root state required for an
+  independent replayer to reconstruct the emitted root statistics.
+
+Consumers call :meth:`~lczerolens.search_trace.SearchTrace.supports` or
+:meth:`~lczerolens.search_trace.SearchTrace.require` before making a claim.
+Requesting full events or replay from an lc0 root-only trace raises
+:class:`~lczerolens.search_trace.SearchCapabilityError`. Schema construction
+also rejects a capability label when its required records are absent.
+
+Representative mappings
+-----------------------
+
+The current Python ``MCTS`` can be represented at
+``root_action_stats``: its legal moves map to UCI strings, policy to ``P``,
+visits to ``N``, and ``q_values`` to ``Q``. It does not retain cumulative
+``W``, source ``U``, budget snapshots, or append-only events, so those fields
+remain absent. Tests exercise this record without upgrading its capability.
+
+Captured lc0 ``VerboseMoveStats`` or ``LogLiveStats`` output maps each reported
+root move and its available P/N/Q/U/PV fields into a budget-labelled root
+snapshot. Reported ``WL`` and ``D`` form the action's search evaluation, while
+``V`` is its separately labelled leaf/network evaluation; unavailable entries
+remain absent. UCI ``bestmove`` supplies the selection. Version, network
+checksum, command options, and requested/observed nodes or time belong to
+provenance and budget records. Unless lc0 exposes simulation transitions
+through a separately supported interface, the adapter advertises at most
+``root_snapshots``. Tests exercise a representative captured-output-shaped
+record without an lc0 binary.
+
+Adapter boundary
+----------------
+
+Search producers implement outside the schema records. The reference adapter
+turns deterministic state transitions into ``SimulationEvent`` values. The lc0
+process adapter owns command invocation and version-specific parsing, then
+returns the same ``SearchTrace`` type. Other engine adapters may do likewise.
+Parsers must fail with actionable version or shape diagnostics rather than
+silently discard a field they claim to support.
+
+Existing API disposition
+------------------------
+
+The existing search implementation remains importable through the 0.x
+compatibility window while #140 supplies its replacement contract:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 24 18 58
+
+   * - Symbol or option
+     - Decision
+     - Rationale
+   * - ``MCTS``
+     - Refocus
+     - Becomes the deterministic, auditable reference search; no production or lc0-fidelity claim.
+   * - ``Node``
+     - Internalize
+     - Mutable tree storage is an implementation detail; trace records are the public evidence boundary.
+   * - ``Heuristic`` and ``ModelHeuristic``
+     - Refocus
+     - Adapt the stable evaluator contract for reference search rather than define a general game-search API.
+   * - ``RandomHeuristic`` and ``MaterialHeuristic``
+     - Retain for tests
+     - Deterministic/reference fixtures only; they are not evaluator standards.
+   * - ``MCTSSampler``
+     - Refocus
+     - Remains a compatibility move-selection facade over the reference search, not an engine service.
+   * - ``MCTSSampler.use_q_values``
+     - Deprecate
+     - Root choice becomes an explicit selection policy over typed action statistics.
+   * - ``MCTS.n_parallel_rollouts``
+     - Deprecate
+     - The v1 reference search is sequential and deterministic; parallel production search stays engine-owned.
+   * - ``MCTS.render_tree``
+     - Internalize
+     - Rendering mutable implementation nodes is not the portable trace contract.
+
+Actual warning and migration behavior accompanies the #140 implementation;
+this design PR does not change runtime search behavior.

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -72,6 +72,14 @@ class SearchBudgetUnit(str, Enum):
     DEPTH = "depth"
 
 
+_COUNT_BUDGET_UNITS = {
+    SearchBudgetUnit.NODES,
+    SearchBudgetUnit.VISITS,
+    SearchBudgetUnit.SIMULATIONS,
+    SearchBudgetUnit.DEPTH,
+}
+
+
 @dataclass(frozen=True)
 class SearchParameter:
     """One source-specific search option retained as provenance."""
@@ -119,6 +127,8 @@ class SearchBudget:
         for name, value in (("requested", self.requested), ("observed", self.observed)):
             if value is not None and (isinstance(value, bool) or not math.isfinite(value) or value < 0):
                 raise ValueError(f"Search budget {name} must be finite and non-negative.")
+            if value is not None and self.unit in _COUNT_BUDGET_UNITS and not isinstance(value, int):
+                raise ValueError(f"Search budget {name} must be an integer for {self.unit.value}.")
 
 
 @dataclass(frozen=True)
@@ -454,6 +464,8 @@ class SearchTrace:
                         variation_board.push(move)
         if not self.snapshots:
             raise ValueError("A search trace must contain at least one root snapshot.")
+        if not any(snapshot.selection is not None or snapshot.evaluation is not None for snapshot in self.snapshots):
+            raise ValueError("A search trace must contain a root selection or evaluation.")
         sequences = [snapshot.sequence for snapshot in self.snapshots]
         if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
             raise ValueError("Root snapshot sequence numbers must be unique and increasing.")

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -1,0 +1,499 @@
+"""Engine-independent records for search evidence.
+
+The records in this module describe what a search source actually exposed.  A
+trace's :class:`SearchCapability` is a promise to consumers; absent engine data
+must stay ``None`` rather than being reconstructed or guessed by an adapter.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import TypeAlias
+
+import chess
+
+
+ParameterValue: TypeAlias = str | int | float | bool | None
+
+
+class SearchCapability(str, Enum):
+    """Ordered information levels supplied by a search trace."""
+
+    ROOT_RESULT = "root_result"
+    ROOT_ACTION_STATS = "root_action_stats"
+    ROOT_SNAPSHOTS = "root_snapshots"
+    FULL_EVENTS = "full_events"
+    REPLAYABLE = "replayable"
+
+    @property
+    def level(self) -> int:
+        """Return the information ordering used by capability checks."""
+        return _CAPABILITY_LEVEL[self]
+
+
+_CAPABILITY_LEVEL = {
+    SearchCapability.ROOT_RESULT: 0,
+    SearchCapability.ROOT_ACTION_STATS: 1,
+    SearchCapability.ROOT_SNAPSHOTS: 2,
+    SearchCapability.FULL_EVENTS: 3,
+    SearchCapability.REPLAYABLE: 4,
+}
+
+
+class SearchCapabilityError(RuntimeError):
+    """Raised when a consumer asks a trace for evidence it does not contain."""
+
+
+class ValuePerspective(str, Enum):
+    """Player whose expected outcome a scalar value or WDL describes."""
+
+    SIDE_TO_MOVE = "side_to_move"
+    ROOT_PLAYER = "root_player"
+    WHITE = "white"
+    BLACK = "black"
+
+
+class ChessPlayer(str, Enum):
+    """An absolute chess player used to identify the root side to move."""
+
+    WHITE = "white"
+    BLACK = "black"
+
+
+class SearchBudgetUnit(str, Enum):
+    """Unit used for a requested or observed search budget."""
+
+    NODES = "nodes"
+    VISITS = "visits"
+    SIMULATIONS = "simulations"
+    TIME_MS = "time_ms"
+    DEPTH = "depth"
+
+
+@dataclass(frozen=True)
+class SearchParameter:
+    """One source-specific search option retained as provenance."""
+
+    name: str
+    value: ParameterValue
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Search parameter names must not be empty.")
+        if isinstance(self.value, float) and not math.isfinite(self.value):
+            raise ValueError(f"Search parameter {self.name!r} must be finite.")
+
+
+@dataclass(frozen=True)
+class SearchProvenance:
+    """Identity and configuration of the producer of a trace."""
+
+    source: str
+    engine: str | None = None
+    engine_version: str | None = None
+    network: str | None = None
+    network_checksum: str | None = None
+    parameters: tuple[SearchParameter, ...] = ()
+
+    def __post_init__(self) -> None:
+        if not self.source:
+            raise ValueError("Search provenance source must not be empty.")
+        names = [parameter.name for parameter in self.parameters]
+        if len(names) != len(set(names)):
+            raise ValueError("Search provenance parameter names must be unique.")
+
+
+@dataclass(frozen=True)
+class SearchBudget:
+    """Requested and observed work for one root result or snapshot."""
+
+    unit: SearchBudgetUnit
+    requested: float | int | None = None
+    observed: float | int | None = None
+
+    def __post_init__(self) -> None:
+        if self.requested is None and self.observed is None:
+            raise ValueError("A search budget needs a requested or observed value.")
+        for name, value in (("requested", self.requested), ("observed", self.observed)):
+            if value is not None and (isinstance(value, bool) or not math.isfinite(value) or value < 0):
+                raise ValueError(f"Search budget {name} must be finite and non-negative.")
+
+
+@dataclass(frozen=True)
+class Wdl:
+    """Win/draw/loss probabilities from one explicit player perspective."""
+
+    win: float
+    draw: float
+    loss: float
+    perspective: ValuePerspective
+
+    def __post_init__(self) -> None:
+        probabilities = (self.win, self.draw, self.loss)
+        if any(not math.isfinite(value) or value < 0 or value > 1 for value in probabilities):
+            raise ValueError("WDL entries must be finite probabilities in [0, 1].")
+        if not math.isclose(sum(probabilities), 1.0, rel_tol=1e-6, abs_tol=1e-6):
+            raise ValueError("WDL probabilities must sum to one.")
+
+    def scalar(self, draw_score: float = 0.0) -> float:
+        """Convert WDL to ``win + draw_score * draw - loss``."""
+        if not math.isfinite(draw_score):
+            raise ValueError("draw_score must be finite.")
+        return self.win + draw_score * self.draw - self.loss
+
+    @classmethod
+    def from_win_loss_draw(
+        cls,
+        win_minus_loss: float,
+        draw: float,
+        perspective: ValuePerspective,
+    ) -> Wdl:
+        """Build WDL from lc0-style ``WL = win - loss`` and draw probability."""
+        win = (1.0 - draw + win_minus_loss) / 2.0
+        loss = (1.0 - draw - win_minus_loss) / 2.0
+        return cls(win=win, draw=draw, loss=loss, perspective=perspective)
+
+
+@dataclass(frozen=True)
+class PositionEvaluation:
+    """An optional scalar and/or WDL evaluation of a position."""
+
+    perspective: ValuePerspective
+    value: float | None = None
+    wdl: Wdl | None = None
+
+    def __post_init__(self) -> None:
+        if self.value is None and self.wdl is None:
+            raise ValueError("A position evaluation needs a scalar value or WDL.")
+        if self.value is not None and (not math.isfinite(self.value) or not -1 <= self.value <= 1):
+            raise ValueError("Scalar position values must be finite and in [-1, 1].")
+        if self.wdl is not None and self.wdl.perspective is not self.perspective:
+            raise ValueError("Scalar and WDL perspectives must agree.")
+
+
+@dataclass(frozen=True)
+class PrincipalVariation:
+    """A source-reported sequence of UCI moves, without inferred continuations."""
+
+    moves: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if not self.moves or any(not move for move in self.moves):
+            raise ValueError("A principal variation must contain non-empty UCI moves.")
+
+
+@dataclass(frozen=True)
+class EdgeStatistics:
+    """Statistics for one directed edge, expressed in its stated perspective.
+
+    ``prior`` is P, ``visits`` is N, ``total_value`` is W, ``mean_value`` is
+    Q, and ``exploration`` is the source-reported U term.  U is retained rather
+    than recomputed because its formula is implementation-specific.
+    """
+
+    move: str
+    perspective: ValuePerspective
+    prior: float | None = None
+    visits: int | None = None
+    total_value: float | None = None
+    mean_value: float | None = None
+    exploration: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.move:
+            raise ValueError("Edge moves must be non-empty UCI strings.")
+        if self.prior is not None and (not math.isfinite(self.prior) or not 0 <= self.prior <= 1):
+            raise ValueError("P must be a finite probability in [0, 1].")
+        if self.visits is not None and (
+            not isinstance(self.visits, int) or isinstance(self.visits, bool) or self.visits < 0
+        ):
+            raise ValueError("N must be a non-negative integer.")
+        for name, value in (("W", self.total_value), ("Q", self.mean_value), ("U", self.exploration)):
+            if value is not None and not math.isfinite(value):
+                raise ValueError(f"{name} must be finite when present.")
+        if self.mean_value is not None and not -1 <= self.mean_value <= 1:
+            raise ValueError("Q must be in [-1, 1].")
+        if self.exploration is not None and self.exploration < 0:
+            raise ValueError("U must be non-negative.")
+        if self.visits is not None and self.total_value is not None and abs(self.total_value) > self.visits + 1e-6:
+            raise ValueError("W must be in [-N, N] for values bounded to [-1, 1].")
+        if self.visits is not None and self.total_value is not None and self.mean_value is not None:
+            expected = self.total_value / self.visits if self.visits else 0.0
+            if not math.isclose(self.mean_value, expected, rel_tol=1e-6, abs_tol=1e-6):
+                raise ValueError("Q must equal W / N, with Q = 0 when N = 0.")
+
+
+@dataclass(frozen=True)
+class RootAction:
+    """One legal root action and exactly the statistics the source exposed."""
+
+    statistics: EdgeStatistics
+    evaluation: PositionEvaluation | None = None
+    leaf_evaluation: PositionEvaluation | None = None
+    principal_variation: PrincipalVariation | None = None
+
+    def __post_init__(self) -> None:
+        if self.principal_variation is not None and self.principal_variation.moves[0] != self.statistics.move:
+            raise ValueError("A root action's principal variation must start with that action.")
+
+
+@dataclass(frozen=True)
+class RootSelection:
+    """Selected root move and the rule used to resolve sampling or ties."""
+
+    move: str
+    rule: str
+    tie_break: str
+    temperature: float | None = None
+
+    def __post_init__(self) -> None:
+        if not self.move or not self.rule or not self.tie_break:
+            raise ValueError("Root selection move, rule, and tie-break must be explicit.")
+        if self.temperature is not None and (not math.isfinite(self.temperature) or self.temperature < 0):
+            raise ValueError("Root selection temperature must be finite and non-negative.")
+
+
+@dataclass(frozen=True)
+class RootSnapshot:
+    """Root evidence at one point in a search.
+
+    ``actions=None`` means the producer did not expose action statistics;
+    ``actions=()`` means it explicitly exposed an empty legal-action set.
+    """
+
+    sequence: int
+    selection: RootSelection | None = None
+    evaluation: PositionEvaluation | None = None
+    budget: SearchBudget | None = None
+    actions: tuple[RootAction, ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.sequence, int) or isinstance(self.sequence, bool) or self.sequence < 0:
+            raise ValueError("Root snapshot sequence must be non-negative.")
+        if self.selection is None and self.evaluation is None and self.actions is None:
+            raise ValueError("A root snapshot needs a selection, evaluation, or exposed actions.")
+        if self.actions is not None:
+            moves = [action.statistics.move for action in self.actions]
+            if len(moves) != len(set(moves)):
+                raise ValueError("Root snapshot actions must have unique moves.")
+            if self.selection is not None and self.selection.move not in moves:
+                raise ValueError("The selected root move must appear in the exposed actions.")
+
+
+@dataclass(frozen=True)
+class PathStep:
+    """One selected parent-edge-child transition in a simulation."""
+
+    node_id: str
+    move: str
+    child_id: str
+
+
+@dataclass(frozen=True)
+class EvaluatorCall:
+    """Evaluator metadata retained for an expanded or evaluated leaf."""
+
+    dtype: str
+    source_device: str
+    search_device: str
+    legal_policy_logits: tuple[tuple[str, float], ...] | None = None
+
+    def __post_init__(self) -> None:
+        if not self.dtype or not self.source_device or not self.search_device:
+            raise ValueError("Evaluator dtype and device fields must be explicit.")
+        if self.legal_policy_logits is not None:
+            moves = [move for move, _ in self.legal_policy_logits]
+            values = [value for _, value in self.legal_policy_logits]
+            if len(moves) != len(set(moves)) or any(not move for move in moves):
+                raise ValueError("Legal policy logits must have unique, non-empty moves.")
+            if any(not math.isfinite(value) for value in values):
+                raise ValueError("Legal policy logits must be finite.")
+
+
+@dataclass(frozen=True)
+class LeafRecord:
+    """Leaf reached by a simulation and the value returned for backup."""
+
+    node_id: str
+    evaluation: PositionEvaluation
+    terminal: bool
+    evaluator: EvaluatorCall | None = None
+
+
+@dataclass(frozen=True)
+class NodeExpansion:
+    """Legal priors created when a node was expanded."""
+
+    node_id: str
+    edges: tuple[EdgeStatistics, ...]
+
+    def __post_init__(self) -> None:
+        moves = [edge.move for edge in self.edges]
+        if len(moves) != len(set(moves)):
+            raise ValueError("Expansion edges must have unique moves.")
+        if any(edge.prior is None for edge in self.edges):
+            raise ValueError("Every expanded edge must have an explicit prior.")
+        if self.edges and not math.isclose(
+            sum(edge.prior for edge in self.edges if edge.prior is not None), 1.0, rel_tol=1e-6, abs_tol=1e-6
+        ):
+            raise ValueError("Expanded legal priors must sum to one.")
+
+
+@dataclass(frozen=True)
+class BackupUpdate:
+    """Pre/post state for one backed-up edge."""
+
+    node_id: str
+    signed_value: float
+    before: EdgeStatistics
+    after: EdgeStatistics
+
+    def __post_init__(self) -> None:
+        if not math.isfinite(self.signed_value) or not -1 <= self.signed_value <= 1:
+            raise ValueError("Backed-up values must be finite and in [-1, 1].")
+        if self.before.move != self.after.move or self.before.perspective is not self.after.perspective:
+            raise ValueError("Backup pre/post records must describe the same edge and perspective.")
+        before = (self.before.visits, self.before.total_value, self.before.mean_value)
+        after = (self.after.visits, self.after.total_value, self.after.mean_value)
+        if any(value is None for value in before + after):
+            raise ValueError("Backup updates require pre/post N, W, and Q.")
+        if self.after.visits != self.before.visits + 1:
+            raise ValueError("Backup updates require N_post = N_pre + 1.")
+        if not math.isclose(
+            self.after.total_value, self.before.total_value + self.signed_value, rel_tol=1e-6, abs_tol=1e-6
+        ):
+            raise ValueError("Backup updates require W_post = W_pre + signed_value.")
+
+
+@dataclass(frozen=True)
+class SimulationEvent:
+    """Append-only evidence for one reference-search simulation."""
+
+    event_id: str
+    simulation: int
+    path: tuple[PathStep, ...]
+    leaf: LeafRecord
+    backups: tuple[BackupUpdate, ...]
+    expansion: NodeExpansion | None = None
+    root_before: tuple[EdgeStatistics, ...] | None = None
+    root_after: tuple[EdgeStatistics, ...] | None = None
+
+    @property
+    def replayable(self) -> bool:
+        """Whether this event contains the state transitions needed for replay."""
+        return self.root_before is not None and self.root_after is not None
+
+    def __post_init__(self) -> None:
+        if (
+            not self.event_id
+            or not isinstance(self.simulation, int)
+            or isinstance(self.simulation, bool)
+            or self.simulation < 0
+        ):
+            raise ValueError("Simulation events need an ID and non-negative index.")
+
+
+@dataclass(frozen=True)
+class SearchTrace:
+    """A capability-labelled sequence of root snapshots and optional events."""
+
+    root_fen: str
+    root_player: ChessPlayer
+    capability: SearchCapability
+    provenance: SearchProvenance
+    snapshots: tuple[RootSnapshot, ...]
+    events: tuple[SimulationEvent, ...] | None = None
+    schema_version: int = field(default=1, init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.root_player, ChessPlayer):
+            raise ValueError("root_player must be ChessPlayer.WHITE or ChessPlayer.BLACK.")
+        try:
+            board = chess.Board(self.root_fen)
+        except ValueError as error:
+            raise ValueError("root_fen must be a valid chess FEN.") from error
+        fen_player = ChessPlayer.WHITE if board.turn is chess.WHITE else ChessPlayer.BLACK
+        if self.root_player is not fen_player:
+            raise ValueError("root_player must match the side to move in root_fen.")
+        legal_moves = {move.uci() for move in board.legal_moves}
+        for snapshot in self.snapshots:
+            if snapshot.selection is not None and snapshot.selection.move not in legal_moves:
+                raise ValueError("The selected root move must be legal in root_fen.")
+            for action in snapshot.actions or ():
+                if action.statistics.move not in legal_moves:
+                    raise ValueError("Every root action must be legal in root_fen.")
+                if action.principal_variation is not None:
+                    variation_board = board.copy(stack=False)
+                    for move_uci in action.principal_variation.moves:
+                        try:
+                            move = chess.Move.from_uci(move_uci)
+                        except ValueError as error:
+                            raise ValueError("Principal variations must contain valid UCI moves.") from error
+                        if move not in variation_board.legal_moves:
+                            raise ValueError("Principal variation moves must be legal in sequence from root_fen.")
+                        variation_board.push(move)
+        if not self.snapshots:
+            raise ValueError("A search trace must contain at least one root snapshot.")
+        sequences = [snapshot.sequence for snapshot in self.snapshots]
+        if sequences != sorted(sequences) or len(sequences) != len(set(sequences)):
+            raise ValueError("Root snapshot sequence numbers must be unique and increasing.")
+        if self.supports(SearchCapability.ROOT_ACTION_STATS) and any(
+            snapshot.actions is None for snapshot in self.snapshots
+        ):
+            raise ValueError("Root-action capability requires actions in every snapshot.")
+        if self.supports(SearchCapability.ROOT_SNAPSHOTS) and any(
+            snapshot.budget is None for snapshot in self.snapshots
+        ):
+            raise ValueError("Root-snapshot capability requires a budget on every snapshot.")
+        if self.supports(SearchCapability.FULL_EVENTS) and self.events is None:
+            raise ValueError("Full-event capability requires an events collection.")
+        if self.events is not None:
+            event_ids = [event.event_id for event in self.events]
+            simulations = [event.simulation for event in self.events]
+            if len(event_ids) != len(set(event_ids)):
+                raise ValueError("Simulation event IDs must be unique.")
+            if simulations != sorted(simulations) or len(simulations) != len(set(simulations)):
+                raise ValueError("Simulation indices must be unique and increasing.")
+        if self.capability is SearchCapability.REPLAYABLE and any(not event.replayable for event in self.events or ()):
+            raise ValueError("Replayable capability requires replay state on every event.")
+
+    def supports(self, capability: SearchCapability) -> bool:
+        """Return whether this trace advertises at least ``capability``."""
+        return self.capability.level >= capability.level
+
+    def require(self, capability: SearchCapability) -> SearchTrace:
+        """Return this trace or reject an unsupported evidence claim."""
+        if not self.supports(capability):
+            raise SearchCapabilityError(
+                f"Trace capability {self.capability.value!r} does not support {capability.value!r}."
+            )
+        return self
+
+
+__all__ = [
+    "BackupUpdate",
+    "ChessPlayer",
+    "EdgeStatistics",
+    "EvaluatorCall",
+    "LeafRecord",
+    "NodeExpansion",
+    "ParameterValue",
+    "PathStep",
+    "PositionEvaluation",
+    "PrincipalVariation",
+    "RootAction",
+    "RootSelection",
+    "RootSnapshot",
+    "SearchBudget",
+    "SearchBudgetUnit",
+    "SearchCapability",
+    "SearchCapabilityError",
+    "SearchParameter",
+    "SearchProvenance",
+    "SearchTrace",
+    "SimulationEvent",
+    "ValuePerspective",
+    "Wdl",
+]

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -280,6 +280,15 @@ class RootSnapshot:
                 raise ValueError("Root snapshot actions must have unique moves.")
             if self.selection is not None and self.selection.move not in moves:
                 raise ValueError("The selected root move must appear in the exposed actions.")
+            priors = [action.statistics.prior for action in self.actions]
+            if (
+                priors
+                and all(prior is not None for prior in priors)
+                and not math.isclose(
+                    sum(prior for prior in priors if prior is not None), 1.0, rel_tol=1e-6, abs_tol=1e-6
+                )
+            ):
+                raise ValueError("Exposed root priors must sum to one.")
 
 
 @dataclass(frozen=True)
@@ -383,7 +392,16 @@ class SimulationEvent:
     @property
     def replayable(self) -> bool:
         """Whether this event contains the state transitions needed for replay."""
-        return self.root_before is not None and self.root_after is not None
+        if not self.root_before or not self.root_after:
+            return False
+        before = {edge.move: edge for edge in self.root_before}
+        after = {edge.move: edge for edge in self.root_after}
+        if len(before) != len(self.root_before) or len(after) != len(self.root_after) or before.keys() != after.keys():
+            return False
+        changed = [(before[move], after[move]) for move in before if before[move] != after[move]]
+        return len(changed) == 1 and any(
+            update.before == changed[0][0] and update.after == changed[0][1] for update in self.backups
+        )
 
     def __post_init__(self) -> None:
         if (
@@ -458,6 +476,16 @@ class SearchTrace:
                 raise ValueError("Simulation indices must be unique and increasing.")
         if self.capability is SearchCapability.REPLAYABLE and any(not event.replayable for event in self.events or ()):
             raise ValueError("Replayable capability requires replay state on every event.")
+        if self.capability is SearchCapability.REPLAYABLE and self.events:
+            for previous, current in zip(self.events, self.events[1:]):
+                if previous.root_after != current.root_before:
+                    raise ValueError("Replayable root states must chain between simulation events.")
+            final_actions = self.snapshots[-1].actions
+            final_root_state = self.events[-1].root_after
+            final_action_stats = {action.statistics.move: action.statistics for action in final_actions or ()}
+            final_event_stats = {edge.move: edge for edge in final_root_state or ()}
+            if final_actions is None or final_root_state is None or final_action_stats != final_event_stats:
+                raise ValueError("Replayable root state must agree with the final root snapshot.")
 
     def supports(self, capability: SearchCapability) -> bool:
         """Return whether this trace advertises at least ``capability``."""

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -410,6 +410,7 @@ def test_replayable_events_require_a_real_root_transition_and_final_state():
         ),
         (lambda: SearchBudget(SearchBudgetUnit.NODES), "requested or observed"),
         (lambda: SearchBudget(SearchBudgetUnit.NODES, requested=-1), "non-negative"),
+        (lambda: SearchBudget(SearchBudgetUnit.NODES, requested=1.5), "must be an integer"),
         (lambda: Wdl(-0.1, 0.5, 0.6, ValuePerspective.ROOT_PLAYER), "probabilities"),
         (lambda: Wdl(0.2, 0.2, 0.2, ValuePerspective.ROOT_PLAYER), "sum to one"),
         (lambda: Wdl(0.5, 0.0, 0.5, ValuePerspective.ROOT_PLAYER).scalar(math.nan), "draw_score"),
@@ -470,6 +471,11 @@ def test_root_and_event_record_validation_errors():
         NodeExpansion("root", (EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=0.5),))
 
 
+def test_time_budget_permits_fractional_milliseconds():
+    budget = SearchBudget(SearchBudgetUnit.TIME_MS, requested=0.5, observed=1.25)
+    assert budget.observed == pytest.approx(1.25)
+
+
 def test_optional_evaluator_and_empty_expansion_records_are_valid():
     EvaluatorCall("float32", "cpu", "cpu")
     EvaluatorCall("float32", "cpu", "cpu", legal_policy_logits=(("e2e4", 0.0),))
@@ -512,6 +518,7 @@ def test_search_trace_validation_errors():
     action_snapshot = RootSnapshot(
         sequence=0,
         budget=SearchBudget(SearchBudgetUnit.NODES, observed=0),
+        evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0),
         actions=(),
     )
     trace_args = dict(
@@ -529,6 +536,15 @@ def test_search_trace_validation_errors():
         SearchTrace(**(trace_args | {"root_fen": START_FEN.replace(" w ", " b ")}))
     with pytest.raises(ValueError, match="must contain at least one"):
         SearchTrace(**(trace_args | {"snapshots": ()}))
+    with pytest.raises(ValueError, match="root selection or evaluation"):
+        SearchTrace(
+            **(
+                trace_args
+                | {
+                    "snapshots": (RootSnapshot(sequence=0, actions=()),),
+                }
+            )
+        )
     with pytest.raises(ValueError, match="unique and increasing"):
         SearchTrace(**(trace_args | {"snapshots": (root_only, root_only)}))
     with pytest.raises(ValueError, match="Full-event capability"):

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -1,0 +1,288 @@
+"""Contracts for engine-independent search trace records."""
+
+import pytest
+
+from lczerolens.search_trace import (
+    BackupUpdate,
+    ChessPlayer,
+    EdgeStatistics,
+    LeafRecord,
+    PositionEvaluation,
+    PrincipalVariation,
+    RootAction,
+    RootSelection,
+    RootSnapshot,
+    SearchBudget,
+    SearchBudgetUnit,
+    SearchCapability,
+    SearchCapabilityError,
+    SearchParameter,
+    SearchProvenance,
+    SearchTrace,
+    SimulationEvent,
+    ValuePerspective,
+    Wdl,
+)
+
+
+START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+
+
+def test_current_python_search_fits_root_action_schema():
+    """The legacy Python MCTS exposes P, N, and Q but need not invent W or U."""
+    trace = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_ACTION_STATS,
+        provenance=SearchProvenance(
+            source="lczerolens-reference",
+            engine="legacy-python-mcts",
+            parameters=(SearchParameter("c_puct", 1.0),),
+        ),
+        snapshots=(
+            RootSnapshot(
+                sequence=0,
+                budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, requested=8, observed=8),
+                selection=RootSelection("e2e4", rule="maximum N", tie_break="legal move order"),
+                actions=(
+                    RootAction(
+                        EdgeStatistics(
+                            move="e2e4",
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            prior=0.6,
+                            visits=5,
+                            mean_value=0.2,
+                        )
+                    ),
+                    RootAction(
+                        EdgeStatistics(
+                            move="d2d4",
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            prior=0.4,
+                            visits=3,
+                            mean_value=0.1,
+                        )
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert trace.supports(SearchCapability.ROOT_ACTION_STATS)
+    assert trace.snapshots[0].actions[0].statistics.total_value is None
+    with pytest.raises(SearchCapabilityError, match="full_events"):
+        trace.require(SearchCapability.FULL_EVENTS)
+
+
+def test_captured_lc0_output_fits_budgeted_root_snapshot_schema():
+    """An lc0 adapter can retain reported root data without claiming events."""
+    trace = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_SNAPSHOTS,
+        provenance=SearchProvenance(
+            source="lc0-verbose-move-stats",
+            engine="lc0",
+            engine_version="v0.31.2",
+            network="example.pb.gz",
+            network_checksum="sha256:fixture",
+            parameters=(SearchParameter("Threads", 1),),
+        ),
+        snapshots=(
+            RootSnapshot(
+                sequence=0,
+                budget=SearchBudget(SearchBudgetUnit.NODES, requested=100, observed=100),
+                evaluation=PositionEvaluation(
+                    perspective=ValuePerspective.ROOT_PLAYER,
+                    wdl=Wdl(0.45, 0.30, 0.25, ValuePerspective.ROOT_PLAYER),
+                ),
+                selection=RootSelection("e2e4", rule="engine bestmove", tie_break="engine-defined"),
+                actions=(
+                    RootAction(
+                        EdgeStatistics(
+                            move="e2e4",
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            prior=0.4,
+                            visits=60,
+                            mean_value=0.18,
+                            exploration=0.03,
+                        ),
+                        evaluation=PositionEvaluation(
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            wdl=Wdl.from_win_loss_draw(0.2, 0.3, ValuePerspective.ROOT_PLAYER),
+                        ),
+                        leaf_evaluation=PositionEvaluation(
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            value=0.18,
+                        ),
+                        principal_variation=PrincipalVariation(("e2e4", "e7e5", "g1f3")),
+                    ),
+                    RootAction(
+                        EdgeStatistics(
+                            move="d2d4",
+                            perspective=ValuePerspective.ROOT_PLAYER,
+                            prior=0.3,
+                            visits=40,
+                            mean_value=0.15,
+                            exploration=0.04,
+                        )
+                    ),
+                ),
+            ),
+        ),
+    )
+
+    assert trace.require(SearchCapability.ROOT_ACTION_STATS) is trace
+    assert trace.events is None
+    assert trace.snapshots[0].evaluation.wdl.scalar() == pytest.approx(0.2)
+    action_wdl = trace.snapshots[0].actions[0].evaluation.wdl
+    assert (action_wdl.win, action_wdl.draw, action_wdl.loss) == pytest.approx((0.45, 0.3, 0.25))
+    assert trace.snapshots[0].actions[0].leaf_evaluation.value == pytest.approx(0.18)
+
+
+def test_root_only_trace_keeps_unavailable_actions_absent():
+    trace = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_RESULT,
+        provenance=SearchProvenance(source="uci"),
+        snapshots=(
+            RootSnapshot(
+                sequence=0,
+                selection=RootSelection("e2e4", rule="bestmove", tie_break="engine-defined"),
+            ),
+        ),
+    )
+
+    assert trace.snapshots[0].actions is None
+    with pytest.raises(SearchCapabilityError, match="root_action_stats"):
+        trace.require(SearchCapability.ROOT_ACTION_STATS)
+
+
+def test_capability_claims_require_their_records():
+    snapshot = RootSnapshot(
+        sequence=0,
+        selection=RootSelection("e2e4", rule="bestmove", tie_break="engine-defined"),
+    )
+
+    with pytest.raises(ValueError, match="requires actions"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.ROOT_ACTION_STATS,
+            provenance=SearchProvenance(source="invalid"),
+            snapshots=(snapshot,),
+        )
+    with pytest.raises(ValueError, match="requires a budget"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.ROOT_SNAPSHOTS,
+            provenance=SearchProvenance(source="invalid"),
+            snapshots=(
+                RootSnapshot(
+                    sequence=0,
+                    evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0),
+                    actions=(),
+                ),
+            ),
+        )
+
+
+def test_q_is_w_over_n_with_explicit_zero_visit_convention():
+    EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=0, total_value=0.0, mean_value=0.0)
+    EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=4, total_value=1.0, mean_value=0.25)
+
+    with pytest.raises(ValueError, match="Q must equal W / N"):
+        EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=4, total_value=1.0, mean_value=0.5)
+
+
+def test_backup_update_enforces_replay_transition():
+    before = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.2, mean_value=0.2)
+    after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=2, total_value=0.5, mean_value=0.25)
+
+    BackupUpdate("root", signed_value=0.3, before=before, after=after)
+    with pytest.raises(ValueError, match="W_post"):
+        BackupUpdate(
+            "root",
+            signed_value=0.4,
+            before=before,
+            after=after,
+        )
+
+
+def test_selected_move_must_be_among_exposed_root_actions():
+    with pytest.raises(ValueError, match="selected root move"):
+        RootSnapshot(
+            sequence=0,
+            selection=RootSelection("e2e4", rule="maximum N", tie_break="UCI order"),
+            actions=(RootAction(EdgeStatistics("d2d4", ValuePerspective.ROOT_PLAYER, visits=1)),),
+        )
+
+
+def test_trace_rejects_illegal_root_actions():
+    with pytest.raises(ValueError, match="legal in root_fen"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.ROOT_RESULT,
+            provenance=SearchProvenance(source="invalid"),
+            snapshots=(
+                RootSnapshot(
+                    sequence=0,
+                    selection=RootSelection("e2e5", rule="bestmove", tie_break="engine-defined"),
+                ),
+            ),
+        )
+
+
+def test_replayable_capability_requires_pre_and_post_root_state():
+    before = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=0, total_value=0.0, mean_value=0.0)
+    after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.5, mean_value=0.5)
+    backup = BackupUpdate("root", signed_value=0.5, before=before, after=after)
+    event = SimulationEvent(
+        event_id="simulation-0",
+        simulation=0,
+        path=(),
+        leaf=LeafRecord(
+            node_id="root",
+            evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.5),
+            terminal=False,
+        ),
+        backups=(backup,),
+    )
+    snapshot = RootSnapshot(
+        sequence=0,
+        budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, observed=1),
+        selection=RootSelection("e2e4", rule="maximum N", tie_break="UCI order"),
+        actions=(RootAction(after),),
+    )
+
+    with pytest.raises(ValueError, match="Replayable capability"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.REPLAYABLE,
+            provenance=SearchProvenance(source="reference"),
+            snapshots=(snapshot,),
+            events=(event,),
+        )
+
+    replayable_event = SimulationEvent(
+        event_id=event.event_id,
+        simulation=event.simulation,
+        path=event.path,
+        leaf=event.leaf,
+        backups=event.backups,
+        root_before=(before,),
+        root_after=(after,),
+    )
+    trace = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.REPLAYABLE,
+        provenance=SearchProvenance(source="reference"),
+        snapshots=(snapshot,),
+        events=(replayable_event,),
+    )
+    assert trace.require(SearchCapability.REPLAYABLE) is trace

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -1,12 +1,17 @@
 """Contracts for engine-independent search trace records."""
 
+import math
+
 import pytest
 
 from lczerolens.search_trace import (
     BackupUpdate,
     ChessPlayer,
     EdgeStatistics,
+    EvaluatorCall,
     LeafRecord,
+    NodeExpansion,
+    PathStep,
     PositionEvaluation,
     PrincipalVariation,
     RootAction,
@@ -286,3 +291,207 @@ def test_replayable_capability_requires_pre_and_post_root_state():
         events=(replayable_event,),
     )
     assert trace.require(SearchCapability.REPLAYABLE) is trace
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: SearchParameter("", 1), "parameter names"),
+        (lambda: SearchParameter("temperature", math.nan), "must be finite"),
+        (lambda: SearchProvenance(source=""), "source must not be empty"),
+        (
+            lambda: SearchProvenance(
+                source="reference", parameters=(SearchParameter("seed", 1), SearchParameter("seed", 2))
+            ),
+            "must be unique",
+        ),
+        (lambda: SearchBudget(SearchBudgetUnit.NODES), "requested or observed"),
+        (lambda: SearchBudget(SearchBudgetUnit.NODES, requested=-1), "non-negative"),
+        (lambda: Wdl(-0.1, 0.5, 0.6, ValuePerspective.ROOT_PLAYER), "probabilities"),
+        (lambda: Wdl(0.2, 0.2, 0.2, ValuePerspective.ROOT_PLAYER), "sum to one"),
+        (lambda: Wdl(0.5, 0.0, 0.5, ValuePerspective.ROOT_PLAYER).scalar(math.nan), "draw_score"),
+        (lambda: PositionEvaluation(ValuePerspective.ROOT_PLAYER), "scalar value or WDL"),
+        (lambda: PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=2.0), r"in \[-1, 1\]"),
+        (
+            lambda: PositionEvaluation(
+                ValuePerspective.ROOT_PLAYER,
+                wdl=Wdl(0.5, 0.0, 0.5, ValuePerspective.WHITE),
+            ),
+            "perspectives must agree",
+        ),
+        (lambda: PrincipalVariation(()), "must contain"),
+        (lambda: EdgeStatistics("", ValuePerspective.ROOT_PLAYER), "non-empty"),
+        (lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=2.0), "P must"),
+        (lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1.5), "N must"),
+        (lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, total_value=math.nan), "W must"),
+        (lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, mean_value=2.0), "Q must"),
+        (lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, exploration=-0.1), "U must"),
+        (
+            lambda: EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=1.1),
+            "W must be in",
+        ),
+        (lambda: RootSelection("", "bestmove", "engine-defined"), "must be explicit"),
+        (lambda: RootSelection("e2e4", "bestmove", "engine-defined", temperature=-1), "non-negative"),
+        (
+            lambda: RootSnapshot(sequence=-1, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0)),
+            "non-negative",
+        ),
+        (lambda: RootSnapshot(sequence=0), "selection, evaluation, or exposed actions"),
+    ],
+)
+def test_record_validation_errors(factory, message):
+    with pytest.raises(ValueError, match=message):
+        factory()
+
+
+def test_root_and_event_record_validation_errors():
+    edge = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=1.0, visits=0)
+    with pytest.raises(ValueError, match="must start"):
+        RootAction(edge, principal_variation=PrincipalVariation(("d2d4",)))
+    with pytest.raises(ValueError, match="unique moves"):
+        RootSnapshot(
+            sequence=0,
+            actions=(RootAction(edge), RootAction(edge)),
+        )
+    with pytest.raises(ValueError, match="dtype and device"):
+        EvaluatorCall("", "cpu", "cpu")
+    with pytest.raises(ValueError, match="unique, non-empty"):
+        EvaluatorCall("float32", "cpu", "cpu", legal_policy_logits=(("e2e4", 0.0), ("e2e4", 1.0)))
+    with pytest.raises(ValueError, match="must be finite"):
+        EvaluatorCall("float32", "cpu", "cpu", legal_policy_logits=(("e2e4", math.nan),))
+    with pytest.raises(ValueError, match="unique moves"):
+        NodeExpansion("root", (edge, edge))
+    with pytest.raises(ValueError, match="explicit prior"):
+        NodeExpansion("root", (EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER),))
+    with pytest.raises(ValueError, match="sum to one"):
+        NodeExpansion("root", (EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=0.5),))
+
+
+def test_optional_evaluator_and_empty_expansion_records_are_valid():
+    EvaluatorCall("float32", "cpu", "cpu")
+    EvaluatorCall("float32", "cpu", "cpu", legal_policy_logits=(("e2e4", 0.0),))
+    NodeExpansion("terminal", ())
+
+
+def test_backup_and_event_validation_errors():
+    before = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=0, total_value=0.0, mean_value=0.0)
+    after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.5, mean_value=0.5)
+    with pytest.raises(ValueError, match=r"in \[-1, 1\]"):
+        BackupUpdate("root", 2.0, before, after)
+    with pytest.raises(ValueError, match="same edge"):
+        BackupUpdate(
+            "root",
+            0.5,
+            before,
+            EdgeStatistics("d2d4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.5, mean_value=0.5),
+        )
+    with pytest.raises(ValueError, match="pre/post N, W, and Q"):
+        BackupUpdate("root", 0.5, EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER), after)
+    with pytest.raises(ValueError, match="N_post"):
+        BackupUpdate(
+            "root",
+            0.5,
+            before,
+            EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=2, total_value=0.5, mean_value=0.25),
+        )
+    with pytest.raises(ValueError, match="ID and non-negative"):
+        SimulationEvent(
+            event_id="",
+            simulation=0,
+            path=(PathStep("root", "e2e4", "child"),),
+            leaf=LeafRecord("child", PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0), False),
+            backups=(),
+        )
+
+
+def test_search_trace_validation_errors():
+    root_only = RootSnapshot(sequence=0, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0))
+    action_snapshot = RootSnapshot(
+        sequence=0,
+        budget=SearchBudget(SearchBudgetUnit.NODES, observed=0),
+        actions=(),
+    )
+    trace_args = dict(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_RESULT,
+        provenance=SearchProvenance(source="test"),
+        snapshots=(root_only,),
+    )
+    with pytest.raises(ValueError, match="root_player must"):
+        SearchTrace(**(trace_args | {"root_player": "white"}))
+    with pytest.raises(ValueError, match="valid chess FEN"):
+        SearchTrace(**(trace_args | {"root_fen": "not a FEN"}))
+    with pytest.raises(ValueError, match="must match"):
+        SearchTrace(**(trace_args | {"root_fen": START_FEN.replace(" w ", " b ")}))
+    with pytest.raises(ValueError, match="must contain at least one"):
+        SearchTrace(**(trace_args | {"snapshots": ()}))
+    with pytest.raises(ValueError, match="unique and increasing"):
+        SearchTrace(**(trace_args | {"snapshots": (root_only, root_only)}))
+    with pytest.raises(ValueError, match="Full-event capability"):
+        SearchTrace(
+            **(
+                trace_args
+                | {
+                    "capability": SearchCapability.FULL_EVENTS,
+                    "snapshots": (action_snapshot,),
+                }
+            )
+        )
+
+    with pytest.raises(ValueError, match="Every root action"):
+        SearchTrace(
+            **(
+                trace_args
+                | {
+                    "snapshots": (
+                        RootSnapshot(
+                            sequence=0,
+                            actions=(RootAction(EdgeStatistics("e2e5", ValuePerspective.ROOT_PLAYER)),),
+                        ),
+                    )
+                }
+            )
+        )
+    for variation, message in (
+        (("e2e4", "not-a-move"), "valid UCI"),
+        (("e2e4", "e2e4"), "legal in sequence"),
+    ):
+        with pytest.raises(ValueError, match=message):
+            SearchTrace(
+                **(
+                    trace_args
+                    | {
+                        "snapshots": (
+                            RootSnapshot(
+                                sequence=0,
+                                actions=(
+                                    RootAction(
+                                        EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER),
+                                        principal_variation=PrincipalVariation(variation),
+                                    ),
+                                ),
+                            ),
+                        )
+                    }
+                )
+            )
+
+    event = SimulationEvent(
+        event_id="event-0",
+        simulation=0,
+        path=(),
+        leaf=LeafRecord("root", PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0), False),
+        backups=(),
+    )
+    with pytest.raises(ValueError, match="IDs must be unique"):
+        SearchTrace(**(trace_args | {"events": (event, event)}))
+    repeated_simulation = SimulationEvent(
+        event_id="event-1",
+        simulation=0,
+        path=(),
+        leaf=event.leaf,
+        backups=(),
+    )
+    with pytest.raises(ValueError, match="indices must be unique"):
+        SearchTrace(**(trace_args | {"events": (event, repeated_simulation)}))

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -107,7 +107,7 @@ def test_captured_lc0_output_fits_budgeted_root_snapshot_schema():
                         EdgeStatistics(
                             move="e2e4",
                             perspective=ValuePerspective.ROOT_PLAYER,
-                            prior=0.4,
+                            prior=0.6,
                             visits=60,
                             mean_value=0.18,
                             exploration=0.03,
@@ -126,7 +126,7 @@ def test_captured_lc0_output_fits_budgeted_root_snapshot_schema():
                         EdgeStatistics(
                             move="d2d4",
                             perspective=ValuePerspective.ROOT_PLAYER,
-                            prior=0.3,
+                            prior=0.4,
                             visits=40,
                             mean_value=0.15,
                             exploration=0.04,
@@ -225,6 +225,17 @@ def test_selected_move_must_be_among_exposed_root_actions():
         )
 
 
+def test_exposed_root_priors_must_sum_to_one():
+    with pytest.raises(ValueError, match="root priors"):
+        RootSnapshot(
+            sequence=0,
+            actions=(
+                RootAction(EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=0.4)),
+                RootAction(EdgeStatistics("d2d4", ValuePerspective.ROOT_PLAYER, prior=0.3)),
+            ),
+        )
+
+
 def test_trace_rejects_illegal_root_actions():
     with pytest.raises(ValueError, match="legal in root_fen"):
         SearchTrace(
@@ -291,6 +302,98 @@ def test_replayable_capability_requires_pre_and_post_root_state():
         events=(replayable_event,),
     )
     assert trace.require(SearchCapability.REPLAYABLE) is trace
+
+
+def test_replayable_events_require_a_real_root_transition_and_final_state():
+    before = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=0, total_value=0.0, mean_value=0.0)
+    after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.5, mean_value=0.5)
+    backup = BackupUpdate("root", signed_value=0.5, before=before, after=after)
+    leaf = LeafRecord("root", PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.5), False)
+    empty_states = SimulationEvent("empty", 0, (), leaf, (backup,), root_before=(), root_after=())
+    duplicate_states = SimulationEvent(
+        "duplicate", 0, (), leaf, (backup,), root_before=(before, before), root_after=(after, after)
+    )
+    unrelated_after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=1, total_value=0.4, mean_value=0.4)
+    unrelated_states = SimulationEvent(
+        "unrelated", 0, (), leaf, (backup,), root_before=(before,), root_after=(unrelated_after,)
+    )
+
+    assert not empty_states.replayable
+    assert not duplicate_states.replayable
+    assert not unrelated_states.replayable
+
+    event = SimulationEvent("event-0", 0, (), leaf, (backup,), root_before=(before,), root_after=(after,))
+    with pytest.raises(ValueError, match="final root snapshot"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.REPLAYABLE,
+            provenance=SearchProvenance(source="reference"),
+            snapshots=(
+                RootSnapshot(
+                    sequence=0,
+                    budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, observed=1),
+                    selection=RootSelection("e2e4", "maximum N", "UCI order"),
+                    actions=(RootAction(unrelated_after),),
+                ),
+            ),
+            events=(event,),
+        )
+
+    next_after = EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, visits=2, total_value=0.7, mean_value=0.35)
+    next_backup = BackupUpdate("root", signed_value=0.2, before=after, after=next_after)
+    chained_event = SimulationEvent(
+        "event-1",
+        1,
+        (),
+        leaf,
+        (next_backup,),
+        root_before=(after,),
+        root_after=(next_after,),
+    )
+    chained_trace = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.REPLAYABLE,
+        provenance=SearchProvenance(source="reference"),
+        snapshots=(
+            RootSnapshot(
+                sequence=0,
+                budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, observed=2),
+                selection=RootSelection("e2e4", "maximum N", "UCI order"),
+                actions=(RootAction(next_after),),
+            ),
+        ),
+        events=(event, chained_event),
+    )
+    assert chained_trace.require(SearchCapability.REPLAYABLE) is chained_trace
+
+    unrelated_edge = EdgeStatistics("d2d4", ValuePerspective.ROOT_PLAYER, visits=0, total_value=0.0, mean_value=0.0)
+    unchained_event = SimulationEvent(
+        "event-1",
+        1,
+        (),
+        leaf,
+        (next_backup,),
+        root_before=(after, unrelated_edge),
+        root_after=(next_after, unrelated_edge),
+    )
+    with pytest.raises(ValueError, match="must chain"):
+        SearchTrace(
+            root_fen=START_FEN,
+            root_player=ChessPlayer.WHITE,
+            capability=SearchCapability.REPLAYABLE,
+            provenance=SearchProvenance(source="reference"),
+            snapshots=(
+                RootSnapshot(
+                    sequence=0,
+                    budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, observed=2),
+                    selection=RootSelection("e2e4", "maximum N", "UCI order"),
+                    actions=(RootAction(next_after), RootAction(unrelated_edge)),
+                ),
+            ),
+            events=(event, unchained_event),
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- define search ownership: production search stays engine-owned, while lczerolens owns a deterministic reference search and engine-independent evidence contract
- add typed, immutable trace records for provenance, budgets, root results/actions/snapshots, P/N/W/Q/U, WDL/value perspectives, leaf evaluations, simulation events, and replay transitions
- make capability levels enforceable so root-only engine output cannot support full-event or replay claims
- document exact statistic, perspective, WDL conversion, selection, tie, adapter, and legacy API disposition semantics
- demonstrate that both the current Python MCTS surface and lc0 VerboseMoveStats-shaped root data fit the schema without inventing unavailable fields

## Why

The existing mutable MCTS tree and sampler API did not define a portable evidence boundary. In particular, consumers could not distinguish root-only engine output from replayable reference-search events, and value/statistic perspectives were implicit. That ambiguity would force #140 and #141 to define incompatible trace formats.

This PR establishes the shared architecture gate before either implementation proceeds. It does not change runtime search behavior; deprecation warnings and migration behavior remain part of #140.

## Validation

- `uv run --group dev pytest -q tests -m unit` — 77 passed, 46 deselected
- `uv run --group dev pre-commit run --all-files` — passed
- `just docs` — succeeded (the existing AutoAPI/notebook warnings remain)

Closes #131