### PR TITLE
Preserve explicit pytest tier markers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,11 +96,11 @@ default-groups = []
 
 [tool.pytest.ini_options]
 markers = [
-    "unit: deterministic tests of library code with no external service or model fixture",
-    "conformance: lc0 compatibility checks that require versioned model fixtures",
-    "integration: tests that exercise notebooks or another process boundary",
-    "network: tests that contact an external service and are never in the offline suite",
-    "slow: tests intended for the explicitly requested slow tier",
+    "unit: deterministic tests of library code with no external service or model fixture (automatic default)",
+    "conformance: lc0 compatibility checks that require versioned model fixtures (explicit primary tier)",
+    "integration: tests that exercise notebooks or another process boundary (explicit primary tier)",
+    "network: tests that contact an external service and are never in the offline suite (explicit primary tier)",
+    "slow: tests intended for the explicitly requested slow tier (explicit primary tier)",
     "backends: legacy alias for an lc0 conformance test",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,8 +95,11 @@ def winner_senet_ort(winner_ensure_network):
 
 
 def pytest_collection_modifyitems(items):
-    """Every test receives an explicit tier marker for stable selection."""
+    """Assign a default tier only when a test has no explicit primary tier."""
+    primary_tiers = {"unit", "conformance", "integration", "network", "slow"}
     for item in items:
+        if primary_tiers & {marker.name for marker in item.iter_markers()}:
+            continue
         path = Path(str(item.fspath))
         if "integration" in path.parts:
             item.add_marker(pytest.mark.integration)

--- a/tests/unit/test_test_tiers.py
+++ b/tests/unit/test_test_tiers.py
@@ -1,0 +1,28 @@
+"""Regression coverage for pytest's mutually exclusive primary test tiers."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parents[2]
+LIVE_LC0_TEST = "tests/unit/test_lc0_adapter.py::test_optional_pinned_lc0_process_adapter"
+
+
+def _collect(marker: str) -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", "tests", "-m", marker, "--co", "-q"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def test_unit_collection_excludes_explicit_integration_test():
+    assert LIVE_LC0_TEST not in _collect("unit")
+
+
+def test_integration_collection_includes_explicit_integration_test():
+    assert LIVE_LC0_TEST in _collect("integration")

--- a/tests/unit/test_test_tiers.py
+++ b/tests/unit/test_test_tiers.py
@@ -9,20 +9,33 @@ ROOT = Path(__file__).parents[2]
 LIVE_LC0_TEST = "tests/unit/test_lc0_adapter.py::test_optional_pinned_lc0_process_adapter"
 
 
-def _collect(marker: str) -> str:
+def _collect(marker: str) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
-        [sys.executable, "-m", "pytest", "tests", "-m", marker, "--co", "-q"],
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            LIVE_LC0_TEST,
+            "-m",
+            marker,
+            "--co",
+            "-q",
+        ],
         cwd=ROOT,
-        check=True,
         capture_output=True,
         text=True,
     )
-    return result.stdout
+    assert result.returncode in {0, 5}, result.stderr
+    return result
 
 
 def test_unit_collection_excludes_explicit_integration_test():
-    assert LIVE_LC0_TEST not in _collect("unit")
+    result = _collect("unit")
+    assert result.returncode == 5
+    assert LIVE_LC0_TEST not in result.stdout
 
 
 def test_integration_collection_includes_explicit_integration_test():
-    assert LIVE_LC0_TEST in _collect("integration")
+    result = _collect("integration")
+    assert result.returncode == 0
+    assert LIVE_LC0_TEST in result.stdout


### PR DESCRIPTION
## Summary

Closes #151.

- Preserve an explicitly assigned primary pytest tier instead of applying the `unit` fallback.
- Document that `unit` is the automatic default and the other primary tiers are explicit.
- Add collection regression tests proving the optional live lc0 adapter is excluded from `-m unit` and included in `-m integration`.

## Why

The opt-in live lc0 adapter test is explicitly marked `integration` but is colocated with adapter unit tests. The collection hook also assigned it `unit`, so the offline suite selected it and emitted an expected skip when live-lc0 environment variables were absent.

## Validation

- `just checks`
- `just tests` — 176 passed, 12 deselected; coverage 83.01%
- `pytest tests -m unit --co -q` excludes the live adapter test
- `pytest tests -m integration --co -q` includes the live adapter test
