### PR TITLE
Add evidence-bearing chess facts

### DIFF
--- a/docs/source/facts.rst
+++ b/docs/source/facts.rst
@@ -1,0 +1,55 @@
+Chess facts and evidence
+========================
+
+``lczerolens.facts`` represents chess observations before a consumer turns them
+into labels, tensors, datasets, metrics, or natural-language claims. Every
+``Evidence`` record states its kind, scope, subject, value or undefined reason,
+perspective, guarantee, supporting chess objects, history requirement, and
+versioned analyzer provenance.
+
+Reference analyzers
+-------------------
+
+The bundled analyzers use only ``python-chess`` and operate on one position:
+
+* ``MaterialAnalyzer`` records a side's material points and every counted piece;
+* ``PiecePresenceAnalyzer`` records whether a side has a piece type and where;
+* ``AttacksDefendersAnalyzer`` records attackers and defenders of a square;
+* ``CheckStatusAnalyzer`` records the king square and checking pieces; and
+* ``LegalMobilityAnalyzer`` records the count and complete set of legal moves.
+
+These analyzers carry the ``exact`` guarantee. An invalid position or missing
+king is returned as explicit undefined evidence where it prevents the requested
+semantics. ``history_is_available`` distinguishes boards played forward with a
+move stack from positions reconstructed from a mid-game FEN.
+
+Composition and guarantees
+--------------------------
+
+``EvidenceSet.compose`` and ``EvidenceSet.filter`` retain the original evidence
+records. Exact, heuristic, engine-derived, and search-derived observations can
+therefore coexist without losing their tags. Extracting bare values through
+``EvidenceSet.values`` requires the caller to name one guarantee and rejects a
+mixed set.
+
+Migration from concepts
+-----------------------
+
+The existing ``lczerolens.concepts`` API remains available during the 0.x
+compatibility period. It computes task-ready labels and optionally owns dataset
+feature or metric conversion. New chess-semantic code should instead compute an
+``Evidence`` first, then explicitly convert ``evidence.value`` for its task.
+
+The direct migrations are:
+
+* ``HasPiece`` to ``PiecePresenceAnalyzer``;
+* ``HasMaterialAdvantage`` to two ``MaterialAnalyzer`` results followed by an
+  explicit comparison; and
+* rule-based threat labels to ``AttacksDefendersAnalyzer`` plus an explicit
+  task predicate.
+
+``BestLegalMove`` and ``PieceBestLegalMove`` are model-derived labels, not exact
+position facts. Keep using them for compatibility or represent a new analyzer's
+result with ``engine-derived`` or ``search-derived`` guarantee as appropriate.
+No dataset, scikit-learn, neural hook, or attribution dependency is imported by
+the core fact API.

--- a/docs/source/facts.rst
+++ b/docs/source/facts.rst
@@ -21,7 +21,8 @@ The bundled analyzers use only ``python-chess`` and operate on one position:
 These analyzers carry the ``exact`` guarantee. An invalid position or missing
 king is returned as explicit undefined evidence where it prevents the requested
 semantics. ``history_is_available`` distinguishes boards played forward with a
-move stack from positions reconstructed from a mid-game FEN.
+move stack rooted at the standard initial position from positions reconstructed
+from an analysis FEN, including FENs with reset move counters.
 
 Composition and guarantees
 --------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,6 +10,7 @@ lczerolens
 
     start
     scope
+    facts
     search
     features
     tutorials

--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -3,6 +3,7 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .board import LczeroBoard
+from .facts import Evidence, EvidenceSet, FactAnalyzer
 from .lc0_adapter import Lc0ProcessAdapter, Lc0RootSnapshotParser, Lc0SearchRequest
 from .model import LczeroModel
 from .reference_search import ReferenceMCTS, replay_root_events
@@ -15,6 +16,9 @@ except PackageNotFoundError:
 __all__ = [
     "LczeroBoard",
     "LczeroModel",
+    "Evidence",
+    "EvidenceSet",
+    "FactAnalyzer",
     "Lc0ProcessAdapter",
     "Lc0RootSnapshotParser",
     "Lc0SearchRequest",

--- a/src/lczerolens/facts.py
+++ b/src/lczerolens/facts.py
@@ -214,6 +214,8 @@ class Evidence:
             raise ValueError("History cannot be unavailable when no history is required.")
         if not self.history_available and self.undefined_reason is not UndefinedReason.HISTORY_UNAVAILABLE:
             raise ValueError("Unavailable required history must make evidence explicitly undefined.")
+        if self.history_available and self.undefined_reason is UndefinedReason.HISTORY_UNAVAILABLE:
+            raise ValueError("History-unavailable evidence must set history_available to False.")
         for square in self.supporting_squares:
             _validate_square(square)
         if len(self.supporting_squares) != len(set(self.supporting_squares)):
@@ -303,16 +305,17 @@ def analyze_facts(board: chess.Board, *analyzers: FactAnalyzer) -> EvidenceSet:
 def history_is_available(board: chess.Board, requirement: HistoryRequirement) -> bool:
     """Report whether a board carries the history required by an analyzer.
 
-    A full stack is identifiable when its length agrees with the FEN ply count.
-    A position reconstructed from a mid-game FEN therefore does not silently
-    claim complete history.
+    A full stack must have the FEN's ply count and be rooted at the standard
+    initial position. A position reconstructed from an analysis FEN therefore
+    does not silently claim complete game history, even when its counters were
+    reset.
     """
     _validate_board(board)
     if requirement is HistoryRequirement.NONE:
         return True
     if requirement is HistoryRequirement.LAST_MOVE:
         return bool(board.move_stack)
-    return len(board.move_stack) == board.ply()
+    return len(board.move_stack) == board.ply() and board.root().fen() == chess.STARTING_FEN
 
 
 _REFERENCE_VERSION = "1"
@@ -336,6 +339,7 @@ class MaterialAnalyzer:
     }
 
     def __init__(self, perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE):
+        _validate_side_perspective(perspective)
         self.perspective = perspective
 
     def analyze(self, board: chess.Board) -> Evidence:
@@ -361,6 +365,7 @@ class PiecePresenceAnalyzer:
         perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE,
     ):
         _validate_piece_type(piece_type)
+        _validate_side_perspective(perspective)
         self.piece_type = piece_type
         self.perspective = perspective
 
@@ -389,6 +394,7 @@ class AttacksDefendersAnalyzer:
         perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE,
     ):
         _validate_square(square)
+        _validate_side_perspective(perspective)
         self.square = square
         self.perspective = perspective
 
@@ -415,6 +421,7 @@ class CheckStatusAnalyzer:
     history_requirement = HistoryRequirement.NONE
 
     def __init__(self, perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE):
+        _validate_side_perspective(perspective)
         self.perspective = perspective
 
     def analyze(self, board: chess.Board) -> Evidence:
@@ -496,11 +503,13 @@ def _pieces_for(board: chess.Board, color: chess.Color, role: str) -> tuple[Supp
 
 
 def _resolve_side(board: chess.Board, perspective: FactPerspective) -> ChessSide:
-    if perspective is FactPerspective.ABSOLUTE:
-        raise ValueError("A side-valued analyzer needs white, black, or side-to-move perspective.")
     if perspective is FactPerspective.SIDE_TO_MOVE:
         return ChessSide.from_color(board.turn)
-    return ChessSide.WHITE if perspective is FactPerspective.WHITE else ChessSide.BLACK
+    if perspective is FactPerspective.WHITE:
+        return ChessSide.WHITE
+    if perspective is FactPerspective.BLACK:
+        return ChessSide.BLACK
+    raise ValueError("A side-valued analyzer needs white, black, or side-to-move perspective.")
 
 
 def _validate_board(board: chess.Board) -> None:
@@ -509,13 +518,21 @@ def _validate_board(board: chess.Board) -> None:
 
 
 def _validate_piece_type(piece_type: chess.PieceType) -> None:
-    if isinstance(piece_type, bool) or piece_type not in chess.PIECE_TYPES:
+    if not isinstance(piece_type, int) or isinstance(piece_type, bool) or piece_type not in chess.PIECE_TYPES:
         raise ValueError("piece_type must be a python-chess piece type.")
 
 
 def _validate_square(square: chess.Square) -> None:
-    if isinstance(square, bool) or square not in chess.SQUARES:
+    if not isinstance(square, int) or isinstance(square, bool) or square not in chess.SQUARES:
         raise ValueError("square must be a python-chess square.")
+
+
+def _validate_side_perspective(perspective: FactPerspective) -> None:
+    if not any(
+        perspective is allowed
+        for allowed in (FactPerspective.WHITE, FactPerspective.BLACK, FactPerspective.SIDE_TO_MOVE)
+    ):
+        raise ValueError("A side-valued analyzer needs white, black, or side-to-move perspective.")
 
 
 __all__ = [

--- a/src/lczerolens/facts.py
+++ b/src/lczerolens/facts.py
@@ -1,0 +1,548 @@
+"""Typed chess facts and exact reference analyzers.
+
+This module describes chess-domain observations without choosing how a consumer
+will turn them into labels, tensors, datasets, or metrics.  Every observation
+retains the perspective, guarantee, supporting chess objects, and analyzer
+provenance needed to interpret it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Callable, Protocol, TypeAlias, runtime_checkable
+
+import chess
+
+
+class FactKind(str, Enum):
+    """Kinds produced by the bundled reference analyzers."""
+
+    MATERIAL = "material"
+    PIECE_PRESENCE = "piece_presence"
+    ATTACKS_DEFENDERS = "attacks_defenders"
+    CHECK_STATUS = "check_status"
+    LEGAL_MOBILITY = "legal_mobility"
+
+
+class FactScope(str, Enum):
+    """Chess object over which a fact is asserted."""
+
+    SIDE = "side"
+    PIECE = "piece"
+    SQUARE = "square"
+    MOVE = "move"
+    REGION = "region"
+    POSITION = "position"
+
+
+class FactPerspective(str, Enum):
+    """Viewpoint used to resolve relative subjects and values."""
+
+    ABSOLUTE = "absolute"
+    WHITE = "white"
+    BLACK = "black"
+    SIDE_TO_MOVE = "side_to_move"
+
+
+class Guarantee(str, Enum):
+    """Strength and origin of an evidence value."""
+
+    EXACT = "exact"
+    HEURISTIC = "heuristic"
+    ENGINE_DERIVED = "engine-derived"
+    SEARCH_DERIVED = "search-derived"
+
+
+class HistoryRequirement(str, Enum):
+    """Position history needed to establish a fact."""
+
+    NONE = "none"
+    LAST_MOVE = "last_move"
+    FULL_MOVE_STACK = "full_move_stack"
+
+
+class UndefinedReason(str, Enum):
+    """Why an analyzer could not establish a value."""
+
+    HISTORY_UNAVAILABLE = "history_unavailable"
+    INVALID_POSITION = "invalid_position"
+    MISSING_KING = "missing_king"
+
+
+class ChessSide(str, Enum):
+    """A concrete side, independent of board perspective."""
+
+    WHITE = "white"
+    BLACK = "black"
+
+    @classmethod
+    def from_color(cls, color: chess.Color) -> ChessSide:
+        """Convert a python-chess color to a concrete side."""
+        return cls.WHITE if color == chess.WHITE else cls.BLACK
+
+    @property
+    def color(self) -> chess.Color:
+        """Return the python-chess color represented by this side."""
+        return chess.WHITE if self is ChessSide.WHITE else chess.BLACK
+
+
+@dataclass(frozen=True)
+class SideSubject:
+    """One concrete chess side."""
+
+    side: ChessSide
+
+
+@dataclass(frozen=True)
+class PieceSubject:
+    """A piece type belonging to one concrete side."""
+
+    piece_type: chess.PieceType
+    side: ChessSide
+
+    def __post_init__(self) -> None:
+        _validate_piece_type(self.piece_type)
+
+
+@dataclass(frozen=True)
+class SquareSubject:
+    """One board square."""
+
+    square: chess.Square
+
+    def __post_init__(self) -> None:
+        _validate_square(self.square)
+
+
+@dataclass(frozen=True)
+class MoveSubject:
+    """One chess move."""
+
+    move: chess.Move
+
+
+@dataclass(frozen=True)
+class RegionSubject:
+    """A named, non-empty collection of board squares."""
+
+    name: str
+    squares: tuple[chess.Square, ...]
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Region subjects need a non-empty name.")
+        if not self.squares:
+            raise ValueError("Region subjects need at least one square.")
+        for square in self.squares:
+            _validate_square(square)
+        if len(self.squares) != len(set(self.squares)):
+            raise ValueError("Region subject squares must be unique.")
+
+
+FactSubject: TypeAlias = SideSubject | PieceSubject | SquareSubject | MoveSubject | RegionSubject
+
+
+@dataclass(frozen=True)
+class SupportingPiece:
+    """A piece and square that support an evidence value."""
+
+    square: chess.Square
+    piece: chess.Piece
+    role: str
+
+    def __post_init__(self) -> None:
+        _validate_square(self.square)
+        if not self.role:
+            raise ValueError("Supporting piece roles must not be empty.")
+
+
+@dataclass(frozen=True)
+class AttacksDefendersValue:
+    """Counts of opponent attackers and friendly defenders of a square."""
+
+    attackers: int
+    defenders: int
+
+    def __post_init__(self) -> None:
+        if self.attackers < 0 or self.defenders < 0:
+            raise ValueError("Attack and defender counts must be non-negative.")
+
+
+FactValue: TypeAlias = bool | int | float | str | AttacksDefendersValue
+
+
+@dataclass(frozen=True)
+class AnalyzerProvenance:
+    """Stable identity and semantic version of an evidence producer."""
+
+    analyzer: str
+    version: str
+
+    def __post_init__(self) -> None:
+        if not self.analyzer or not self.version:
+            raise ValueError("Analyzer provenance needs a non-empty analyzer and version.")
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """One evidence-bearing chess fact.
+
+    ``value`` is absent exactly when ``undefined_reason`` is present.  Supporting
+    pieces, squares, and moves are retained even when a downstream consumer only
+    needs the scalar value.
+    """
+
+    kind: FactKind
+    scope: FactScope
+    subject: FactSubject
+    value: FactValue | None
+    perspective: FactPerspective
+    guarantee: Guarantee
+    provenance: AnalyzerProvenance
+    supporting_pieces: tuple[SupportingPiece, ...] = ()
+    supporting_squares: tuple[chess.Square, ...] = ()
+    supporting_moves: tuple[chess.Move, ...] = ()
+    history_requirement: HistoryRequirement = HistoryRequirement.NONE
+    history_available: bool = True
+    undefined_reason: UndefinedReason | None = None
+
+    def __post_init__(self) -> None:
+        if (self.value is None) == (self.undefined_reason is None):
+            raise ValueError("Evidence needs exactly one of value or undefined_reason.")
+        if self.history_requirement is HistoryRequirement.NONE and not self.history_available:
+            raise ValueError("History cannot be unavailable when no history is required.")
+        if not self.history_available and self.undefined_reason is not UndefinedReason.HISTORY_UNAVAILABLE:
+            raise ValueError("Unavailable required history must make evidence explicitly undefined.")
+        for square in self.supporting_squares:
+            _validate_square(square)
+        if len(self.supporting_squares) != len(set(self.supporting_squares)):
+            raise ValueError("Supporting squares must be unique.")
+        if len(self.supporting_moves) != len(set(self.supporting_moves)):
+            raise ValueError("Supporting moves must be unique.")
+
+    @property
+    def is_defined(self) -> bool:
+        """Whether the analyzer established a value."""
+        return self.undefined_reason is None
+
+
+class GuaranteeMismatchError(ValueError):
+    """Raised when a consumer requests values under a different guarantee."""
+
+
+@dataclass(frozen=True)
+class EvidenceSet:
+    """An immutable collection that composes and filters without retagging facts."""
+
+    items: tuple[Evidence, ...] = ()
+
+    def __iter__(self):
+        return iter(self.items)
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def compose(self, *others: Evidence | EvidenceSet) -> EvidenceSet:
+        """Return the concatenation of this evidence and other evidence."""
+        items = list(self.items)
+        for other in others:
+            items.extend(other.items if isinstance(other, EvidenceSet) else (other,))
+        return EvidenceSet(tuple(items))
+
+    def filter(
+        self,
+        *,
+        kind: FactKind | None = None,
+        scope: FactScope | None = None,
+        guarantee: Guarantee | None = None,
+        predicate: Callable[[Evidence], bool] | None = None,
+    ) -> EvidenceSet:
+        """Select evidence while preserving each original record unchanged."""
+        return EvidenceSet(
+            tuple(
+                evidence
+                for evidence in self.items
+                if (kind is None or evidence.kind is kind)
+                and (scope is None or evidence.scope is scope)
+                and (guarantee is None or evidence.guarantee is guarantee)
+                and (predicate is None or predicate(evidence))
+            )
+        )
+
+    def values(self, *, guarantee: Guarantee) -> tuple[FactValue, ...]:
+        """Return defined values only after an explicit guarantee check."""
+        mismatches = [item.guarantee for item in self.items if item.guarantee is not guarantee]
+        if mismatches:
+            raise GuaranteeMismatchError(f"Evidence set contains guarantees other than {guarantee.value}.")
+        return tuple(item.value for item in self.items if item.value is not None)
+
+
+@runtime_checkable
+class FactAnalyzer(Protocol):
+    """Protocol implemented by chess fact analyzers."""
+
+    kind: FactKind
+    scope: FactScope
+    guarantee: Guarantee
+    provenance: AnalyzerProvenance
+    history_requirement: HistoryRequirement
+    perspective: FactPerspective
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        """Analyze a single position and return one uniform evidence record."""
+        ...
+
+
+def analyze_facts(board: chess.Board, *analyzers: FactAnalyzer) -> EvidenceSet:
+    """Run analyzers on one position without introducing batching semantics."""
+    _validate_board(board)
+    return EvidenceSet(tuple(analyzer.analyze(board) for analyzer in analyzers))
+
+
+def history_is_available(board: chess.Board, requirement: HistoryRequirement) -> bool:
+    """Report whether a board carries the history required by an analyzer.
+
+    A full stack is identifiable when its length agrees with the FEN ply count.
+    A position reconstructed from a mid-game FEN therefore does not silently
+    claim complete history.
+    """
+    _validate_board(board)
+    if requirement is HistoryRequirement.NONE:
+        return True
+    if requirement is HistoryRequirement.LAST_MOVE:
+        return bool(board.move_stack)
+    return len(board.move_stack) == board.ply()
+
+
+_REFERENCE_VERSION = "1"
+
+
+class MaterialAnalyzer:
+    """Compute exact material points for one perspective-resolved side."""
+
+    kind = FactKind.MATERIAL
+    scope = FactScope.SIDE
+    guarantee = Guarantee.EXACT
+    provenance = AnalyzerProvenance("lczerolens.reference.material", _REFERENCE_VERSION)
+    history_requirement = HistoryRequirement.NONE
+    piece_values = {
+        chess.PAWN: 1,
+        chess.KNIGHT: 3,
+        chess.BISHOP: 3,
+        chess.ROOK: 5,
+        chess.QUEEN: 9,
+        chess.KING: 0,
+    }
+
+    def __init__(self, perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE):
+        self.perspective = perspective
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        _validate_board(board)
+        side = _resolve_side(board, self.perspective)
+        pieces = _pieces_for(board, side.color, "material")
+        value = sum(self.piece_values[item.piece.piece_type] for item in pieces)
+        return _defined(self, SideSubject(side), value, pieces=pieces)
+
+
+class PiecePresenceAnalyzer:
+    """Determine whether one perspective-resolved side has a piece type."""
+
+    kind = FactKind.PIECE_PRESENCE
+    scope = FactScope.PIECE
+    guarantee = Guarantee.EXACT
+    provenance = AnalyzerProvenance("lczerolens.reference.piece_presence", _REFERENCE_VERSION)
+    history_requirement = HistoryRequirement.NONE
+
+    def __init__(
+        self,
+        piece_type: chess.PieceType,
+        perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE,
+    ):
+        _validate_piece_type(piece_type)
+        self.piece_type = piece_type
+        self.perspective = perspective
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        _validate_board(board)
+        side = _resolve_side(board, self.perspective)
+        pieces = tuple(
+            SupportingPiece(square, board.piece_at(square), "present")
+            for square in sorted(board.pieces(self.piece_type, side.color))
+        )
+        return _defined(self, PieceSubject(self.piece_type, side), bool(pieces), pieces=pieces)
+
+
+class AttacksDefendersAnalyzer:
+    """Count enemy attackers and friendly defenders of a square."""
+
+    kind = FactKind.ATTACKS_DEFENDERS
+    scope = FactScope.SQUARE
+    guarantee = Guarantee.EXACT
+    provenance = AnalyzerProvenance("lczerolens.reference.attacks_defenders", _REFERENCE_VERSION)
+    history_requirement = HistoryRequirement.NONE
+
+    def __init__(
+        self,
+        square: chess.Square,
+        perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE,
+    ):
+        _validate_square(square)
+        self.square = square
+        self.perspective = perspective
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        _validate_board(board)
+        side = _resolve_side(board, self.perspective)
+        attacker_squares = sorted(board.attackers(not side.color, self.square))
+        defender_squares = sorted(board.attackers(side.color, self.square))
+        pieces = tuple(
+            SupportingPiece(square, board.piece_at(square), "attacker") for square in attacker_squares
+        ) + tuple(SupportingPiece(square, board.piece_at(square), "defender") for square in defender_squares)
+        squares = tuple(dict.fromkeys((self.square, *attacker_squares, *defender_squares)))
+        value = AttacksDefendersValue(len(attacker_squares), len(defender_squares))
+        return _defined(self, SquareSubject(self.square), value, pieces=pieces, squares=squares)
+
+
+class CheckStatusAnalyzer:
+    """Determine exactly whether a perspective-resolved king is attacked."""
+
+    kind = FactKind.CHECK_STATUS
+    scope = FactScope.SIDE
+    guarantee = Guarantee.EXACT
+    provenance = AnalyzerProvenance("lczerolens.reference.check_status", _REFERENCE_VERSION)
+    history_requirement = HistoryRequirement.NONE
+
+    def __init__(self, perspective: FactPerspective = FactPerspective.SIDE_TO_MOVE):
+        self.perspective = perspective
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        _validate_board(board)
+        side = _resolve_side(board, self.perspective)
+        king = board.king(side.color)
+        if king is None:
+            return _undefined(self, SideSubject(side), UndefinedReason.MISSING_KING)
+        attacker_squares = sorted(board.attackers(not side.color, king))
+        pieces = tuple(SupportingPiece(square, board.piece_at(square), "checking") for square in attacker_squares)
+        squares = tuple((king, *attacker_squares))
+        return _defined(self, SideSubject(side), bool(attacker_squares), pieces=pieces, squares=squares)
+
+
+class LegalMobilityAnalyzer:
+    """Count and retain all legal moves for the current side to move."""
+
+    kind = FactKind.LEGAL_MOBILITY
+    scope = FactScope.SIDE
+    guarantee = Guarantee.EXACT
+    provenance = AnalyzerProvenance("lczerolens.reference.legal_mobility", _REFERENCE_VERSION)
+    history_requirement = HistoryRequirement.NONE
+    perspective = FactPerspective.SIDE_TO_MOVE
+
+    def analyze(self, board: chess.Board) -> Evidence:
+        _validate_board(board)
+        side = ChessSide.from_color(board.turn)
+        if board.status() != chess.STATUS_VALID:
+            return _undefined(self, SideSubject(side), UndefinedReason.INVALID_POSITION)
+        moves = tuple(board.generate_legal_moves())
+        pieces = tuple(SupportingPiece(move.from_square, board.piece_at(move.from_square), "mobile") for move in moves)
+        return _defined(self, SideSubject(side), len(moves), pieces=pieces, moves=moves)
+
+
+def _defined(
+    analyzer: FactAnalyzer,
+    subject: FactSubject,
+    value: FactValue,
+    *,
+    pieces: tuple[SupportingPiece, ...] = (),
+    squares: tuple[chess.Square, ...] = (),
+    moves: tuple[chess.Move, ...] = (),
+) -> Evidence:
+    return Evidence(
+        kind=analyzer.kind,
+        scope=analyzer.scope,
+        subject=subject,
+        value=value,
+        perspective=analyzer.perspective,
+        guarantee=analyzer.guarantee,
+        provenance=analyzer.provenance,
+        supporting_pieces=pieces,
+        supporting_squares=squares,
+        supporting_moves=moves,
+        history_requirement=analyzer.history_requirement,
+    )
+
+
+def _undefined(analyzer: FactAnalyzer, subject: FactSubject, reason: UndefinedReason) -> Evidence:
+    return Evidence(
+        kind=analyzer.kind,
+        scope=analyzer.scope,
+        subject=subject,
+        value=None,
+        perspective=analyzer.perspective,
+        guarantee=analyzer.guarantee,
+        provenance=analyzer.provenance,
+        history_requirement=analyzer.history_requirement,
+        undefined_reason=reason,
+    )
+
+
+def _pieces_for(board: chess.Board, color: chess.Color, role: str) -> tuple[SupportingPiece, ...]:
+    return tuple(
+        SupportingPiece(square, piece, role)
+        for square, piece in sorted(board.piece_map().items())
+        if piece.color == color
+    )
+
+
+def _resolve_side(board: chess.Board, perspective: FactPerspective) -> ChessSide:
+    if perspective is FactPerspective.ABSOLUTE:
+        raise ValueError("A side-valued analyzer needs white, black, or side-to-move perspective.")
+    if perspective is FactPerspective.SIDE_TO_MOVE:
+        return ChessSide.from_color(board.turn)
+    return ChessSide.WHITE if perspective is FactPerspective.WHITE else ChessSide.BLACK
+
+
+def _validate_board(board: chess.Board) -> None:
+    if not isinstance(board, chess.Board):
+        raise TypeError("Fact analyzers require a python-chess Board.")
+
+
+def _validate_piece_type(piece_type: chess.PieceType) -> None:
+    if isinstance(piece_type, bool) or piece_type not in chess.PIECE_TYPES:
+        raise ValueError("piece_type must be a python-chess piece type.")
+
+
+def _validate_square(square: chess.Square) -> None:
+    if isinstance(square, bool) or square not in chess.SQUARES:
+        raise ValueError("square must be a python-chess square.")
+
+
+__all__ = [
+    "AnalyzerProvenance",
+    "AttacksDefendersAnalyzer",
+    "AttacksDefendersValue",
+    "CheckStatusAnalyzer",
+    "ChessSide",
+    "Evidence",
+    "EvidenceSet",
+    "FactAnalyzer",
+    "FactKind",
+    "FactPerspective",
+    "FactScope",
+    "Guarantee",
+    "GuaranteeMismatchError",
+    "HistoryRequirement",
+    "LegalMobilityAnalyzer",
+    "MaterialAnalyzer",
+    "MoveSubject",
+    "PiecePresenceAnalyzer",
+    "PieceSubject",
+    "RegionSubject",
+    "SideSubject",
+    "SquareSubject",
+    "SupportingPiece",
+    "UndefinedReason",
+    "analyze_facts",
+    "history_is_available",
+]

--- a/tests/unit/test_facts.py
+++ b/tests/unit/test_facts.py
@@ -21,8 +21,12 @@ from lczerolens.facts import (
     HistoryRequirement,
     LegalMobilityAnalyzer,
     MaterialAnalyzer,
+    MoveSubject,
     PiecePresenceAnalyzer,
+    RegionSubject,
     SideSubject,
+    SquareSubject,
+    SupportingPiece,
     UndefinedReason,
     analyze_facts,
     history_is_available,
@@ -139,6 +143,15 @@ def test_history_loss_is_detectable_and_must_be_encoded_as_undefined():
     assert not history_fact.is_defined
 
 
+def test_reset_fen_counters_do_not_claim_complete_history():
+    reset_analysis_fen = chess.Board("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1")
+
+    assert reset_analysis_fen.ply() == 0
+    assert not reset_analysis_fen.move_stack
+    assert not history_is_available(reset_analysis_fen, HistoryRequirement.FULL_MOVE_STACK)
+    assert history_is_available(chess.Board(), HistoryRequirement.FULL_MOVE_STACK)
+
+
 def test_evidence_invariants_reject_ambiguous_undefined_state():
     base = CheckStatusAnalyzer().analyze(chess.Board())
 
@@ -152,6 +165,25 @@ def test_evidence_invariants_reject_ambiguous_undefined_state():
             undefined_reason=UndefinedReason.INVALID_POSITION,
             value=None,
         )
+    with pytest.raises(ValueError, match="must set history_available to False"):
+        replace(
+            base,
+            history_requirement=HistoryRequirement.LAST_MOVE,
+            undefined_reason=UndefinedReason.HISTORY_UNAVAILABLE,
+            value=None,
+        )
+    with pytest.raises(ValueError, match="no history is required"):
+        replace(
+            base,
+            value=None,
+            history_available=False,
+            undefined_reason=UndefinedReason.HISTORY_UNAVAILABLE,
+        )
+    with pytest.raises(ValueError, match="Supporting squares must be unique"):
+        replace(base, supporting_squares=(chess.E1, chess.E1))
+    move = chess.Move.from_uci("e2e4")
+    with pytest.raises(ValueError, match="Supporting moves must be unique"):
+        replace(base, supporting_moves=(move, move))
 
 
 def test_composition_and_filtering_preserve_guarantees():
@@ -165,6 +197,9 @@ def test_composition_and_filtering_preserve_guarantees():
 
     assert evidence.filter(guarantee=Guarantee.EXACT).items == (exact,)
     assert evidence.filter(guarantee=Guarantee.HEURISTIC).items == (heuristic,)
+    assert EvidenceSet((exact,)).values(guarantee=Guarantee.EXACT) == (exact.value,)
+    filtered = evidence.filter(kind=FactKind.MATERIAL, scope=FactScope.SIDE, predicate=lambda item: item.is_defined)
+    assert len(filtered) == 2
     with pytest.raises(GuaranteeMismatchError, match="other than exact"):
         evidence.values(guarantee=Guarantee.EXACT)
 
@@ -174,7 +209,43 @@ def test_analyzers_reject_malformed_inputs_and_configuration():
         MaterialAnalyzer().analyze("not a board")
     with pytest.raises(ValueError, match="piece type"):
         PiecePresenceAnalyzer(99)
+    with pytest.raises(ValueError, match="piece type"):
+        PiecePresenceAnalyzer(1.0)
     with pytest.raises(ValueError, match="square"):
         AttacksDefendersAnalyzer(99)
+    with pytest.raises(ValueError, match="square"):
+        AttacksDefendersAnalyzer(1.0)
     with pytest.raises(ValueError, match="needs white, black"):
-        MaterialAnalyzer(FactPerspective.ABSOLUTE).analyze(chess.Board())
+        MaterialAnalyzer(FactPerspective.ABSOLUTE)
+    with pytest.raises(ValueError, match="needs white, black"):
+        MaterialAnalyzer("white")
+
+    analyzer = MaterialAnalyzer()
+    analyzer.perspective = "white"
+    with pytest.raises(ValueError, match="needs white, black"):
+        analyzer.analyze(chess.Board())
+
+
+def test_subject_and_support_records_reject_malformed_configuration():
+    with pytest.raises(ValueError, match="non-empty name"):
+        RegionSubject("", (chess.A1,))
+    with pytest.raises(ValueError, match="at least one square"):
+        RegionSubject("center", ())
+    with pytest.raises(ValueError, match="must be unique"):
+        RegionSubject("center", (chess.D4, chess.D4))
+    with pytest.raises(ValueError, match="roles must not be empty"):
+        SupportingPiece(chess.A1, chess.Piece(chess.ROOK, chess.WHITE), "")
+    with pytest.raises(ValueError, match="non-negative"):
+        AttacksDefendersValue(-1, 0)
+    with pytest.raises(ValueError, match="non-negative"):
+        AttacksDefendersValue(0, -1)
+    with pytest.raises(ValueError, match="non-empty analyzer and version"):
+        AnalyzerProvenance("", "1")
+    with pytest.raises(ValueError, match="non-empty analyzer and version"):
+        AnalyzerProvenance("test", "")
+    with pytest.raises(ValueError, match="square"):
+        SquareSubject(1.0)
+
+    assert RegionSubject("center", (chess.D4, chess.E4)).squares == (chess.D4, chess.E4)
+    assert MoveSubject(chess.Move.from_uci("e2e4")).move.uci() == "e2e4"
+    assert history_is_available(chess.Board(), HistoryRequirement.NONE)

--- a/tests/unit/test_facts.py
+++ b/tests/unit/test_facts.py
@@ -1,0 +1,180 @@
+"""Tests for evidence-bearing chess facts and exact reference analyzers."""
+
+from dataclasses import replace
+
+import chess
+import pytest
+
+from lczerolens.facts import (
+    AnalyzerProvenance,
+    AttacksDefendersAnalyzer,
+    AttacksDefendersValue,
+    CheckStatusAnalyzer,
+    Evidence,
+    EvidenceSet,
+    FactAnalyzer,
+    FactKind,
+    FactPerspective,
+    FactScope,
+    Guarantee,
+    GuaranteeMismatchError,
+    HistoryRequirement,
+    LegalMobilityAnalyzer,
+    MaterialAnalyzer,
+    PiecePresenceAnalyzer,
+    SideSubject,
+    UndefinedReason,
+    analyze_facts,
+    history_is_available,
+)
+
+
+def test_reference_analyzers_return_uniform_exact_evidence():
+    board = chess.Board("4k3/5n2/8/4P3/2N5/8/8/4K3 w - - 0 1")
+    evidence = analyze_facts(
+        board,
+        MaterialAnalyzer(),
+        PiecePresenceAnalyzer(chess.KNIGHT),
+        AttacksDefendersAnalyzer(chess.E5),
+        CheckStatusAnalyzer(),
+        LegalMobilityAnalyzer(),
+    )
+
+    assert len(evidence) == 5
+    assert all(item.guarantee is Guarantee.EXACT for item in evidence)
+    assert all(item.perspective is FactPerspective.SIDE_TO_MOVE for item in evidence)
+    assert all(item.provenance.version == "1" for item in evidence)
+    assert evidence.items[0].value == 4
+    assert evidence.items[1].value is True
+    assert evidence.items[2].value == AttacksDefendersValue(1, 1)
+    assert evidence.items[2].supporting_squares == (chess.E5, chess.F7, chess.C4)
+    assert evidence.items[3].value is False
+    assert evidence.items[4].value == len(evidence.items[4].supporting_moves)
+    assert all(isinstance(analyzer, FactAnalyzer) for analyzer in (MaterialAnalyzer(), LegalMobilityAnalyzer()))
+
+
+def test_material_and_piece_presence_are_symmetric_by_absolute_side():
+    board = chess.Board("4k3/8/8/8/8/8/PP6/4K3 w - - 0 1")
+    mirrored = board.mirror()
+
+    white_material = MaterialAnalyzer(FactPerspective.WHITE).analyze(board)
+    black_material = MaterialAnalyzer(FactPerspective.BLACK).analyze(mirrored)
+    white_pawns = PiecePresenceAnalyzer(chess.PAWN, FactPerspective.WHITE).analyze(board)
+    black_pawns = PiecePresenceAnalyzer(chess.PAWN, FactPerspective.BLACK).analyze(mirrored)
+
+    assert white_material.value == black_material.value == 2
+    assert len(white_material.supporting_pieces) == len(black_material.supporting_pieces) == 3
+    assert white_pawns.value is black_pawns.value is True
+
+
+def test_attack_check_and_mobility_analyzers_preserve_color_flip_symmetry():
+    board = chess.Board("4k3/5n2/8/4P3/2N5/8/4R3/4K3 b - - 0 1")
+    mirrored = board.mirror()
+
+    attack = AttacksDefendersAnalyzer(chess.E5, FactPerspective.WHITE).analyze(board)
+    mirrored_attack = AttacksDefendersAnalyzer(chess.E4, FactPerspective.BLACK).analyze(mirrored)
+    check = CheckStatusAnalyzer(FactPerspective.BLACK).analyze(board)
+    mirrored_check = CheckStatusAnalyzer(FactPerspective.WHITE).analyze(mirrored)
+    mobility = LegalMobilityAnalyzer().analyze(board)
+    mirrored_mobility = LegalMobilityAnalyzer().analyze(mirrored)
+
+    assert attack.value == mirrored_attack.value
+    assert check.value == mirrored_check.value
+    assert mobility.value == mirrored_mobility.value
+
+
+def test_check_evidence_identifies_king_and_checking_piece():
+    board = chess.Board("4k3/8/8/8/8/8/4R3/4K3 b - - 0 1")
+    evidence = CheckStatusAnalyzer().analyze(board)
+
+    assert evidence.value is True
+    assert evidence.supporting_squares == (chess.E8, chess.E2)
+    assert evidence.supporting_pieces[0].piece == chess.Piece(chess.ROOK, chess.WHITE)
+    assert evidence.supporting_pieces[0].role == "checking"
+
+
+def test_legal_mobility_retains_each_legal_move():
+    evidence = LegalMobilityAnalyzer().analyze(chess.Board())
+
+    assert evidence.value == 20
+    assert len(evidence.supporting_moves) == 20
+    assert chess.Move.from_uci("e2e4") in evidence.supporting_moves
+
+
+def test_malformed_position_is_explicitly_undefined_where_semantics_require_it():
+    missing_king = chess.Board("8/8/8/8/8/8/8/4K3 b - - 0 1")
+
+    check = CheckStatusAnalyzer().analyze(missing_king)
+    mobility = LegalMobilityAnalyzer().analyze(missing_king)
+
+    assert check.value is None
+    assert check.undefined_reason is UndefinedReason.MISSING_KING
+    assert mobility.value is None
+    assert mobility.undefined_reason is UndefinedReason.INVALID_POSITION
+    assert not check.is_defined
+
+
+def test_history_loss_is_detectable_and_must_be_encoded_as_undefined():
+    complete = chess.Board()
+    complete.push_uci("e2e4")
+    reconstructed = chess.Board(complete.fen())
+
+    assert history_is_available(complete, HistoryRequirement.LAST_MOVE)
+    assert history_is_available(complete, HistoryRequirement.FULL_MOVE_STACK)
+    assert not history_is_available(reconstructed, HistoryRequirement.LAST_MOVE)
+    assert not history_is_available(reconstructed, HistoryRequirement.FULL_MOVE_STACK)
+
+    history_fact = Evidence(
+        kind=FactKind.CHECK_STATUS,
+        scope=FactScope.SIDE,
+        subject=SideSubject(side=CheckStatusAnalyzer().analyze(reconstructed).subject.side),
+        value=None,
+        perspective=FactPerspective.SIDE_TO_MOVE,
+        guarantee=Guarantee.EXACT,
+        provenance=AnalyzerProvenance("test.last_move", "1"),
+        history_requirement=HistoryRequirement.LAST_MOVE,
+        history_available=False,
+        undefined_reason=UndefinedReason.HISTORY_UNAVAILABLE,
+    )
+    assert not history_fact.is_defined
+
+
+def test_evidence_invariants_reject_ambiguous_undefined_state():
+    base = CheckStatusAnalyzer().analyze(chess.Board())
+
+    with pytest.raises(ValueError, match="exactly one"):
+        replace(base, value=None, undefined_reason=None)
+    with pytest.raises(ValueError, match="Unavailable required history"):
+        replace(
+            base,
+            history_requirement=HistoryRequirement.LAST_MOVE,
+            history_available=False,
+            undefined_reason=UndefinedReason.INVALID_POSITION,
+            value=None,
+        )
+
+
+def test_composition_and_filtering_preserve_guarantees():
+    exact = MaterialAnalyzer().analyze(chess.Board())
+    heuristic = replace(
+        exact,
+        guarantee=Guarantee.HEURISTIC,
+        provenance=AnalyzerProvenance("example.heuristic", "1"),
+    )
+    evidence = EvidenceSet((exact,)).compose(heuristic)
+
+    assert evidence.filter(guarantee=Guarantee.EXACT).items == (exact,)
+    assert evidence.filter(guarantee=Guarantee.HEURISTIC).items == (heuristic,)
+    with pytest.raises(GuaranteeMismatchError, match="other than exact"):
+        evidence.values(guarantee=Guarantee.EXACT)
+
+
+def test_analyzers_reject_malformed_inputs_and_configuration():
+    with pytest.raises(TypeError, match="python-chess Board"):
+        MaterialAnalyzer().analyze("not a board")
+    with pytest.raises(ValueError, match="piece type"):
+        PiecePresenceAnalyzer(99)
+    with pytest.raises(ValueError, match="square"):
+        AttacksDefendersAnalyzer(99)
+    with pytest.raises(ValueError, match="needs white, black"):
+        MaterialAnalyzer(FactPerspective.ABSOLUTE).analyze(chess.Board())


### PR DESCRIPTION
## Summary

- add immutable, typed `Evidence` records with explicit kind, scope, subject, perspective, guarantee, history state, supporting chess objects, and versioned analyzer provenance
- add composable `EvidenceSet` filtering and guarantee-gated value extraction so exact and heuristic/engine/search-derived facts remain distinguishable
- add exact single-position reference analyzers for material, piece presence, attacks/defenders, check status, and legal mobility using only `python-chess`
- add explicit undefined results for missing-king and invalid-position cases, plus history-availability detection for FEN-reconstructed positions
- document the migration boundary from legacy `Concept` label/metric APIs to evidence-first analysis

## Impact

Consumers can compute chess-semantic observations independently of datasets, scikit-learn, neural hooks, attribution frameworks, or downstream label/tensor conversion. Existing `Concept` APIs remain available during the documented 0.x compatibility period.

## Validation

- `just tests` — 186 passed, 12 deselected, 83.9% coverage
- `uv run --group dev pre-commit run --all-files`
- `cd docs && uv run --group docs make html` — succeeded; existing AutoAPI/cross-reference warnings only
- focused facts suite — 10 passed

Closes #132