### PR TITLE
Add move-delta and variation-evidence primitives

### DIFF
--- a/docs/source/facts.rst
+++ b/docs/source/facts.rst
@@ -54,3 +54,34 @@ position facts. Keep using them for compatibility or represent a new analyzer's
 result with ``engine-derived`` or ``search-derived`` guarantee as appropriate.
 No dataset, scikit-learn, neural hook, or attribution dependency is imported by
 the core fact API.
+
+Move deltas and variation evidence
+----------------------------------
+
+``lczerolens.move_evidence`` composes the exact fact analyzers across legal
+moves. ``analyze_move_delta`` records the before and after FEN, concrete mover,
+moving and captured pieces, special-move metadata, and the original evidence on
+both sides of every changed fact. Its ``created`` and ``removed`` collections
+are set-difference views, while ``preserved`` retains unchanged controls and
+``transitions`` links corresponding before/after records.
+
+Calling ``analyze_move_delta`` without an explicit analyzer list uses
+``exact_move_analyzers``: material, check status, piece presence, and
+attack/defender facts for both concrete sides, plus side-to-move mobility. This
+makes alternating perspectives explicit instead of silently comparing "us" at
+one ply with a different "us" at the next.
+
+``analyze_variation`` applies the same comparison to every ply of an ordered
+legal line. Its position snapshots state whether the board carries complete
+standard-game history. Truncated histories can be retained explicitly or
+rejected with ``HistoryPolicy.REQUIRE_COMPLETE``. Empty or illegal lines,
+history incompatibility, and declared candidate/response mismatches raise
+``VariationAnalysisError`` with a stable ``VariationFailureReason`` and
+position/ply context.
+
+``VariationIntent`` can mark a line as neutral, as support for a named claim by
+a candidate, or as an opponent response that refutes that claim. These records
+do not generate prose and do not infer heuristic notions such as initiative or
+compensation. Terminal result metadata uses rule-exact ``python-chess``
+outcomes; history-dependent draw claims are considered only when complete
+history is available.

--- a/docs/source/facts.rst
+++ b/docs/source/facts.rst
@@ -83,5 +83,6 @@ position/ply context.
 a candidate, or as an opponent response that refutes that claim. These records
 do not generate prose and do not infer heuristic notions such as initiative or
 compensation. Terminal result metadata uses rule-exact ``python-chess``
-outcomes; history-dependent draw claims are considered only when complete
-history is available.
+outcomes. ``VariationTerminal.claimable_draw`` separately records a threefold
+or fifty-move draw that can be claimed when complete history is available; it
+does not turn a legally continuable position into a terminal result.

--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -6,6 +6,7 @@ from .board import LczeroBoard
 from .facts import Evidence, EvidenceSet, FactAnalyzer
 from .lc0_adapter import Lc0ProcessAdapter, Lc0RootSnapshotParser, Lc0SearchRequest
 from .model import LczeroModel
+from .move_evidence import MoveDelta, VariationEvidence, analyze_move_delta, analyze_variation
 from .reference_search import ReferenceMCTS, replay_root_events
 
 try:
@@ -22,6 +23,10 @@ __all__ = [
     "Lc0ProcessAdapter",
     "Lc0RootSnapshotParser",
     "Lc0SearchRequest",
+    "MoveDelta",
     "ReferenceMCTS",
+    "VariationEvidence",
+    "analyze_move_delta",
+    "analyze_variation",
     "replay_root_events",
 ]

--- a/src/lczerolens/move_evidence.py
+++ b/src/lczerolens/move_evidence.py
@@ -173,6 +173,7 @@ class VariationTerminal:
     result: str
     winner: ChessSide | None
     termination: chess.Termination | None
+    claimable_draw: bool
 
 
 @dataclass(frozen=True)
@@ -287,10 +288,10 @@ def analyze_variation(
     initial = _position_evidence(current, initial_set)
     deltas: list[MoveDelta] = []
     for ply_index, move in enumerate(line):
-        if not isinstance(move, chess.Move) or move not in current.legal_moves:
+        if not _is_legal_move(current, move):
             raise VariationAnalysisError(
                 VariationFailureReason.ILLEGAL_MOVE,
-                f"Illegal variation move at ply {ply_index}: {move!s}.",
+                f"Illegal variation move at ply {ply_index}: {_move_label(move)}.",
                 ply_index=ply_index,
                 move=move if isinstance(move, chess.Move) else None,
                 fen=current.fen(),
@@ -299,12 +300,17 @@ def analyze_variation(
         deltas.append(delta)
         current.push(move)
     final = deltas[-1].after
-    outcome = current.outcome(claim_draw=complete)
+    outcome = current.outcome()
     terminal = VariationTerminal(
         is_terminal=outcome is not None,
         result=outcome.result() if outcome is not None else "*",
         winner=ChessSide.from_color(outcome.winner) if outcome is not None and outcome.winner is not None else None,
         termination=outcome.termination if outcome is not None else None,
+        claimable_draw=(
+            complete
+            and outcome is None
+            and (current.can_claim_fifty_moves() or current.can_claim_threefold_repetition())
+        ),
     )
     return VariationEvidence(
         initial=initial,
@@ -392,13 +398,16 @@ def _position_evidence(board: chess.Board, evidence: EvidenceSet) -> PositionEvi
 def _move_evidence(board: chess.Board, move: chess.Move) -> MoveEvidence:
     moving_piece = board.piece_at(move.from_square)
     assert moving_piece is not None
-    en_passant = board.is_en_passant(move)
-    capture_square = move.to_square
-    if en_passant:
-        capture_square += -8 if board.turn == chess.WHITE else 8
-    captured_piece = board.piece_at(capture_square)
     is_castling = board.is_castling(move)
-    rook_move = _castling_rook_move(board.turn, move) if is_castling else None
+    en_passant = board.is_en_passant(move)
+    capture_square: chess.Square | None = None
+    captured_piece: chess.Piece | None = None
+    if not is_castling:
+        capture_square = move.to_square
+        if en_passant:
+            capture_square += -8 if board.turn == chess.WHITE else 8
+        captured_piece = board.piece_at(capture_square)
+    rook_move = _castling_rook_move(board, move) if is_castling else None
     was_check = board.is_check()
     after = board.copy(stack=False)
     after.push(move)
@@ -426,23 +435,43 @@ def _move_evidence(board: chess.Board, move: chess.Move) -> MoveEvidence:
     )
 
 
-def _castling_rook_move(color: chess.Color, move: chess.Move) -> chess.Move:
-    rank = 0 if color == chess.WHITE else 7
-    if chess.square_file(move.to_square) > chess.square_file(move.from_square):
-        return chess.Move(chess.square(7, rank), chess.square(5, rank))
-    return chess.Move(chess.square(0, rank), chess.square(3, rank))
+def _castling_rook_move(board: chess.Board, move: chess.Move) -> chess.Move:
+    rank = chess.square_rank(move.from_square)
+    kingside = board.is_kingside_castling(move)
+    if board.chess960:
+        rook_from = move.to_square
+    elif kingside:
+        rook_from = chess.square(7, rank)
+    else:
+        rook_from = chess.square(0, rank)
+    rook_to = chess.square(5 if kingside else 3, rank)
+    return chess.Move(rook_from, rook_to)
 
 
 def _validate_board_and_move(board: chess.Board, move: chess.Move) -> None:
     if not isinstance(board, chess.Board):
         raise TypeError("Move-delta analysis requires a python-chess Board.")
-    if not isinstance(move, chess.Move) or move not in board.legal_moves:
+    if not _is_legal_move(board, move):
         raise VariationAnalysisError(
             VariationFailureReason.ILLEGAL_MOVE,
-            f"Move is not legal in the supplied position: {move!s}.",
+            f"Move is not legal in the supplied position: {_move_label(move)}.",
             move=move if isinstance(move, chess.Move) else None,
             fen=board.fen(),
         )
+
+
+def _is_well_formed_move(move: object) -> bool:
+    return isinstance(move, chess.Move) and move.from_square in chess.SQUARES and move.to_square in chess.SQUARES
+
+
+def _is_legal_move(board: chess.Board, move: object) -> bool:
+    return _is_well_formed_move(move) and move in board.legal_moves
+
+
+def _move_label(move: object) -> str:
+    if not _is_well_formed_move(move):
+        return "<malformed move>"
+    return chess.square_name(move.from_square) + chess.square_name(move.to_square)
 
 
 def _validate_intent_line(intent: VariationIntent, line: tuple[chess.Move, ...], fen: str) -> None:

--- a/src/lczerolens/move_evidence.py
+++ b/src/lczerolens/move_evidence.py
@@ -1,0 +1,479 @@
+"""Exact move deltas and variation evidence built from chess facts.
+
+This module compares evidence records across legal moves.  It deliberately
+describes only rule-exact changes and retains the original evidence objects;
+interpretations such as initiative or compensation belong to downstream code.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Iterable
+
+import chess
+
+from .facts import (
+    AttacksDefendersAnalyzer,
+    CheckStatusAnalyzer,
+    ChessSide,
+    Evidence,
+    EvidenceSet,
+    FactAnalyzer,
+    FactKind,
+    FactPerspective,
+    HistoryRequirement,
+    LegalMobilityAnalyzer,
+    MaterialAnalyzer,
+    PiecePresenceAnalyzer,
+    analyze_facts,
+    history_is_available,
+)
+
+
+class ExactMoveEffect(str, Enum):
+    """Rule-exact effects established directly from a legal move."""
+
+    CAPTURE = "capture"
+    CHECK = "check"
+    EVASION = "evasion"
+    PROMOTION = "promotion"
+    CASTLING = "castling"
+    EN_PASSANT = "en_passant"
+
+
+class EvidenceTransitionKind(str, Enum):
+    """Whether one semantic fact was retained or changed."""
+
+    PRESERVED = "preserved"
+    CHANGED = "changed"
+
+
+class HistoryPolicy(str, Enum):
+    """How variation analysis treats a truncated input move stack."""
+
+    ALLOW_TRUNCATED = "allow_truncated"
+    REQUIRE_COMPLETE = "require_complete"
+
+
+class VariationRole(str, Enum):
+    """Machine-readable purpose of a line relative to a claim."""
+
+    NEUTRAL = "neutral"
+    CANDIDATE_SUPPORT = "candidate_support"
+    OPPONENT_REFUTATION = "opponent_refutation"
+
+
+class VariationFailureReason(str, Enum):
+    """Structured reasons why a variation could not be analyzed."""
+
+    EMPTY_LINE = "empty_line"
+    ILLEGAL_MOVE = "illegal_move"
+    HISTORY_INCOMPATIBLE = "history_incompatible"
+    INTENT_MISMATCH = "intent_mismatch"
+
+
+@dataclass(frozen=True)
+class PositionEvidence:
+    """Stable position identity and the facts observed there."""
+
+    fen: str
+    turn: ChessSide
+    ply: int
+    history_complete: bool
+    evidence: EvidenceSet
+
+    @property
+    def history_truncated(self) -> bool:
+        """Whether the position lacks a complete standard-game move stack."""
+        return not self.history_complete
+
+
+@dataclass(frozen=True)
+class MoveEvidence:
+    """Exact position and chess-object provenance for one legal move."""
+
+    move: chess.Move
+    mover: ChessSide
+    moving_piece: chess.Piece
+    captured_piece: chess.Piece | None
+    capture_square: chess.Square | None
+    rook_move: chess.Move | None
+    effects: tuple[ExactMoveEffect, ...]
+
+
+@dataclass(frozen=True)
+class EvidenceTransition:
+    """The before/after evidence records for one semantic fact."""
+
+    before: Evidence
+    after: Evidence
+    kind: EvidenceTransitionKind
+
+    def __post_init__(self) -> None:
+        same_value = _same_fact_value(self.before, self.after)
+        if self.kind is EvidenceTransitionKind.PRESERVED and not same_value:
+            raise ValueError("Preserved transitions require the same fact identity and value.")
+        if self.kind is EvidenceTransitionKind.CHANGED and same_value:
+            raise ValueError("Changed transitions require a different fact identity or value.")
+
+
+@dataclass(frozen=True)
+class MoveDelta:
+    """Deterministic fact-set changes caused by one legal move.
+
+    ``created`` and ``removed`` are the mathematical set-difference views.  A
+    changed semantic fact contributes its after record to ``created`` and its
+    before record to ``removed``.  ``transitions`` links both original records.
+    """
+
+    before: PositionEvidence
+    after: PositionEvidence
+    move: MoveEvidence
+    created: EvidenceSet
+    removed: EvidenceSet
+    preserved: EvidenceSet
+    transitions: tuple[EvidenceTransition, ...]
+
+    @property
+    def changed(self) -> tuple[EvidenceTransition, ...]:
+        """Return transitions whose fact value or defined state changed."""
+        return tuple(item for item in self.transitions if item.kind is EvidenceTransitionKind.CHANGED)
+
+
+@dataclass(frozen=True)
+class VariationIntent:
+    """A structured claim relation for a candidate line."""
+
+    role: VariationRole = VariationRole.NEUTRAL
+    claim_id: str | None = None
+    candidate: chess.Move | None = None
+    response: chess.Move | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.role, VariationRole):
+            raise ValueError("Variation intent role must be a VariationRole.")
+        if self.role is VariationRole.NEUTRAL:
+            if any(item is not None for item in (self.claim_id, self.candidate, self.response)):
+                raise ValueError("Neutral variation intent cannot name a claim, candidate, or response.")
+            return
+        if not self.claim_id or self.candidate is None:
+            raise ValueError("Claim-related variation intent needs a claim_id and candidate move.")
+        if self.role is VariationRole.CANDIDATE_SUPPORT and self.response is not None:
+            raise ValueError("Candidate-support intent does not take a refuting response.")
+        if self.role is VariationRole.OPPONENT_REFUTATION and self.response is None:
+            raise ValueError("Opponent-refutation intent needs the opponent response.")
+
+
+@dataclass(frozen=True)
+class VariationTerminal:
+    """Rule result at the end of an analyzed line."""
+
+    is_terminal: bool
+    result: str
+    winner: ChessSide | None
+    termination: chess.Termination | None
+
+
+@dataclass(frozen=True)
+class VariationEvidence:
+    """Evidence for an ordered legal line, one exact delta per ply."""
+
+    initial: PositionEvidence
+    final: PositionEvidence
+    deltas: tuple[MoveDelta, ...]
+    intent: VariationIntent
+    history_policy: HistoryPolicy
+    terminal: VariationTerminal
+
+    @property
+    def moves(self) -> tuple[chess.Move, ...]:
+        """Return the analyzed move sequence."""
+        return tuple(delta.move.move for delta in self.deltas)
+
+
+class VariationAnalysisError(ValueError):
+    """A variation failure with stable machine-readable context."""
+
+    def __init__(
+        self,
+        reason: VariationFailureReason,
+        message: str,
+        *,
+        ply_index: int | None = None,
+        move: chess.Move | None = None,
+        fen: str | None = None,
+    ):
+        super().__init__(message)
+        self.reason = reason
+        self.ply_index = ply_index
+        self.move = move
+        self.fen = fen
+
+
+def exact_move_analyzers() -> tuple[FactAnalyzer, ...]:
+    """Return the complete bundled exact analyzer suite for move comparison.
+
+    Both concrete sides are analyzed where meaningful.  Attack/defender facts
+    cover every square from both sides' perspectives; legal mobility remains a
+    side-to-move fact by definition.
+    """
+    analyzers: list[FactAnalyzer] = []
+    for perspective in (FactPerspective.WHITE, FactPerspective.BLACK):
+        analyzers.extend(
+            (
+                MaterialAnalyzer(perspective),
+                CheckStatusAnalyzer(perspective),
+                *(PiecePresenceAnalyzer(piece_type, perspective) for piece_type in chess.PIECE_TYPES),
+                *(AttacksDefendersAnalyzer(square, perspective) for square in chess.SQUARES),
+            )
+        )
+    analyzers.append(LegalMobilityAnalyzer())
+    return tuple(analyzers)
+
+
+def analyze_move_delta(
+    board: chess.Board,
+    move: chess.Move,
+    *analyzers: FactAnalyzer,
+) -> MoveDelta:
+    """Apply one legal move and compare exact evidence before and after it."""
+    _validate_board_and_move(board, move)
+    selected = tuple(analyzers) or exact_move_analyzers()
+    before_set = analyze_facts(board, *selected)
+    move_evidence = _move_evidence(board, move)
+    after_board = board.copy(stack=True)
+    after_board.push(move)
+    after_set = analyze_facts(after_board, *selected)
+    created, removed, preserved, transitions = _compare_evidence(before_set, after_set)
+    return MoveDelta(
+        before=_position_evidence(board, before_set),
+        after=_position_evidence(after_board, after_set),
+        move=move_evidence,
+        created=created,
+        removed=removed,
+        preserved=preserved,
+        transitions=transitions,
+    )
+
+
+def analyze_variation(
+    board: chess.Board,
+    moves: Iterable[chess.Move],
+    *analyzers: FactAnalyzer,
+    intent: VariationIntent | None = None,
+    history_policy: HistoryPolicy = HistoryPolicy.ALLOW_TRUNCATED,
+) -> VariationEvidence:
+    """Analyze a non-empty ordered legal line with explicit history policy."""
+    if not isinstance(board, chess.Board):
+        raise TypeError("Variation analysis requires a python-chess Board.")
+    if not isinstance(history_policy, HistoryPolicy):
+        raise ValueError("history_policy must be a HistoryPolicy.")
+    line = tuple(moves)
+    if not line:
+        raise VariationAnalysisError(VariationFailureReason.EMPTY_LINE, "A variation needs at least one move.")
+    complete = history_is_available(board, HistoryRequirement.FULL_MOVE_STACK)
+    if history_policy is HistoryPolicy.REQUIRE_COMPLETE and not complete:
+        raise VariationAnalysisError(
+            VariationFailureReason.HISTORY_INCOMPATIBLE,
+            "The variation requires a complete move stack rooted at the standard initial position.",
+            fen=board.fen(),
+        )
+    resolved_intent = intent or VariationIntent()
+    _validate_intent_line(resolved_intent, line, board.fen())
+    selected = tuple(analyzers) or exact_move_analyzers()
+    current = board.copy(stack=True)
+    initial_set = analyze_facts(current, *selected)
+    initial = _position_evidence(current, initial_set)
+    deltas: list[MoveDelta] = []
+    for ply_index, move in enumerate(line):
+        if not isinstance(move, chess.Move) or move not in current.legal_moves:
+            raise VariationAnalysisError(
+                VariationFailureReason.ILLEGAL_MOVE,
+                f"Illegal variation move at ply {ply_index}: {move!s}.",
+                ply_index=ply_index,
+                move=move if isinstance(move, chess.Move) else None,
+                fen=current.fen(),
+            )
+        delta = analyze_move_delta(current, move, *selected)
+        deltas.append(delta)
+        current.push(move)
+    final = deltas[-1].after
+    outcome = current.outcome(claim_draw=complete)
+    terminal = VariationTerminal(
+        is_terminal=outcome is not None,
+        result=outcome.result() if outcome is not None else "*",
+        winner=ChessSide.from_color(outcome.winner) if outcome is not None and outcome.winner is not None else None,
+        termination=outcome.termination if outcome is not None else None,
+    )
+    return VariationEvidence(
+        initial=initial,
+        final=final,
+        deltas=tuple(deltas),
+        intent=resolved_intent,
+        history_policy=history_policy,
+        terminal=terminal,
+    )
+
+
+def _compare_evidence(
+    before: EvidenceSet,
+    after: EvidenceSet,
+) -> tuple[EvidenceSet, EvidenceSet, EvidenceSet, tuple[EvidenceTransition, ...]]:
+    unmatched_after = list(after.items)
+    preserved: list[Evidence] = []
+    changed: list[EvidenceTransition] = []
+    removed_only: list[Evidence] = []
+    created_only: list[Evidence] = []
+    for before_item in before:
+        key_index = next(
+            (index for index, item in enumerate(unmatched_after) if _evidence_key(item) == _evidence_key(before_item)),
+            None,
+        )
+        if key_index is None:
+            removed_only.append(before_item)
+            continue
+        after_item = unmatched_after.pop(key_index)
+        if _same_fact_value(before_item, after_item):
+            preserved.append(before_item)
+            changed.append(EvidenceTransition(before_item, after_item, EvidenceTransitionKind.PRESERVED))
+        else:
+            changed.append(EvidenceTransition(before_item, after_item, EvidenceTransitionKind.CHANGED))
+            removed_only.append(before_item)
+            created_only.append(after_item)
+    created_only.extend(unmatched_after)
+    return (
+        EvidenceSet(tuple(created_only)),
+        EvidenceSet(tuple(removed_only)),
+        EvidenceSet(tuple(preserved)),
+        tuple(changed),
+    )
+
+
+def _evidence_key(evidence: Evidence) -> tuple[object, ...]:
+    return (
+        evidence.kind,
+        evidence.scope,
+        evidence.subject,
+        evidence.perspective,
+        evidence.guarantee,
+        evidence.provenance,
+        evidence.history_requirement,
+    )
+
+
+def _same_fact_value(before: Evidence, after: Evidence) -> bool:
+    same_value = (
+        _evidence_key(before) == _evidence_key(after)
+        and before.value == after.value
+        and before.undefined_reason is after.undefined_reason
+        and before.history_available is after.history_available
+    )
+    if not same_value:
+        return False
+    if before.kind in (FactKind.ATTACKS_DEFENDERS, FactKind.CHECK_STATUS):
+        return (
+            before.supporting_pieces == after.supporting_pieces
+            and before.supporting_squares == after.supporting_squares
+        )
+    return True
+
+
+def _position_evidence(board: chess.Board, evidence: EvidenceSet) -> PositionEvidence:
+    return PositionEvidence(
+        fen=board.fen(),
+        turn=ChessSide.from_color(board.turn),
+        ply=board.ply(),
+        history_complete=history_is_available(board, HistoryRequirement.FULL_MOVE_STACK),
+        evidence=evidence,
+    )
+
+
+def _move_evidence(board: chess.Board, move: chess.Move) -> MoveEvidence:
+    moving_piece = board.piece_at(move.from_square)
+    assert moving_piece is not None
+    en_passant = board.is_en_passant(move)
+    capture_square = move.to_square
+    if en_passant:
+        capture_square += -8 if board.turn == chess.WHITE else 8
+    captured_piece = board.piece_at(capture_square)
+    is_castling = board.is_castling(move)
+    rook_move = _castling_rook_move(board.turn, move) if is_castling else None
+    was_check = board.is_check()
+    after = board.copy(stack=False)
+    after.push(move)
+    effects: list[ExactMoveEffect] = []
+    if captured_piece is not None:
+        effects.append(ExactMoveEffect.CAPTURE)
+    if after.is_check():
+        effects.append(ExactMoveEffect.CHECK)
+    if was_check:
+        effects.append(ExactMoveEffect.EVASION)
+    if move.promotion is not None:
+        effects.append(ExactMoveEffect.PROMOTION)
+    if is_castling:
+        effects.append(ExactMoveEffect.CASTLING)
+    if en_passant:
+        effects.append(ExactMoveEffect.EN_PASSANT)
+    return MoveEvidence(
+        move=move,
+        mover=ChessSide.from_color(board.turn),
+        moving_piece=moving_piece,
+        captured_piece=captured_piece,
+        capture_square=capture_square if captured_piece is not None else None,
+        rook_move=rook_move,
+        effects=tuple(effects),
+    )
+
+
+def _castling_rook_move(color: chess.Color, move: chess.Move) -> chess.Move:
+    rank = 0 if color == chess.WHITE else 7
+    if chess.square_file(move.to_square) > chess.square_file(move.from_square):
+        return chess.Move(chess.square(7, rank), chess.square(5, rank))
+    return chess.Move(chess.square(0, rank), chess.square(3, rank))
+
+
+def _validate_board_and_move(board: chess.Board, move: chess.Move) -> None:
+    if not isinstance(board, chess.Board):
+        raise TypeError("Move-delta analysis requires a python-chess Board.")
+    if not isinstance(move, chess.Move) or move not in board.legal_moves:
+        raise VariationAnalysisError(
+            VariationFailureReason.ILLEGAL_MOVE,
+            f"Move is not legal in the supplied position: {move!s}.",
+            move=move if isinstance(move, chess.Move) else None,
+            fen=board.fen(),
+        )
+
+
+def _validate_intent_line(intent: VariationIntent, line: tuple[chess.Move, ...], fen: str) -> None:
+    mismatch = False
+    if intent.role is VariationRole.CANDIDATE_SUPPORT:
+        mismatch = line[0] != intent.candidate
+    elif intent.role is VariationRole.OPPONENT_REFUTATION:
+        mismatch = len(line) < 2 or line[0] != intent.candidate or line[1] != intent.response
+    if mismatch:
+        raise VariationAnalysisError(
+            VariationFailureReason.INTENT_MISMATCH,
+            "The analyzed line does not match its declared candidate/response intent.",
+            fen=fen,
+        )
+
+
+__all__ = [
+    "EvidenceTransition",
+    "EvidenceTransitionKind",
+    "ExactMoveEffect",
+    "HistoryPolicy",
+    "MoveDelta",
+    "MoveEvidence",
+    "PositionEvidence",
+    "VariationAnalysisError",
+    "VariationEvidence",
+    "VariationFailureReason",
+    "VariationIntent",
+    "VariationRole",
+    "VariationTerminal",
+    "analyze_move_delta",
+    "analyze_variation",
+    "exact_move_analyzers",
+]

--- a/tests/unit/test_move_evidence.py
+++ b/tests/unit/test_move_evidence.py
@@ -144,6 +144,22 @@ def test_special_moves_have_explicit_exact_metadata(fen, uci, effects, capture_s
     assert (delta.move.rook_move.uci() if delta.move.rook_move else None) == rook_uci
 
 
+def test_chess960_castling_moves_the_configured_rook_without_a_capture():
+    board = chess.Board(None, chess960=True)
+    board.set_piece_at(chess.G1, chess.Piece(chess.KING, chess.WHITE))
+    board.set_piece_at(chess.H1, chess.Piece(chess.ROOK, chess.WHITE))
+    board.set_piece_at(chess.E8, chess.Piece(chess.KING, chess.BLACK))
+    board.castling_rights = chess.BB_H1
+    move = chess.Move(chess.G1, chess.H1)
+
+    delta = analyze_move_delta(board, move, MaterialAnalyzer())
+
+    assert delta.move.effects == (ExactMoveEffect.CASTLING,)
+    assert delta.move.captured_piece is None
+    assert delta.move.capture_square is None
+    assert delta.move.rook_move == chess.Move(chess.H1, chess.F1)
+
+
 def test_unchanged_control_is_preserved_without_losing_original_evidence():
     board = chess.Board()
     before = MaterialAnalyzer(FactPerspective.WHITE).analyze(board)
@@ -183,6 +199,15 @@ def test_transition_and_input_validation_rejects_inconsistent_records():
         analyze_move_delta(chess.Board(), "not a move")
     assert illegal.value.reason is VariationFailureReason.ILLEGAL_MOVE
     assert illegal.value.move is None
+    malformed = chess.Move(64, chess.E4)
+    with pytest.raises(VariationAnalysisError) as malformed_delta:
+        analyze_move_delta(chess.Board(), malformed)
+    assert malformed_delta.value.reason is VariationFailureReason.ILLEGAL_MOVE
+    assert malformed_delta.value.move == malformed
+    with pytest.raises(VariationAnalysisError) as malformed_variation:
+        analyze_variation(chess.Board(), (malformed,))
+    assert malformed_variation.value.reason is VariationFailureReason.ILLEGAL_MOVE
+    assert malformed_variation.value.ply_index == 0
     with pytest.raises(TypeError, match="Variation analysis"):
         analyze_variation("not a board", (chess.Move.from_uci("e2e4"),))
     with pytest.raises(ValueError, match="history_policy"):
@@ -208,6 +233,19 @@ def test_variation_tracks_alternating_perspective_terminal_result_and_intent():
     assert variation.terminal.result == "1-0"
     assert variation.terminal.winner.value == "white"
     assert variation.terminal.termination is chess.Termination.CHECKMATE
+    assert not variation.terminal.claimable_draw
+
+
+def test_claimable_draw_is_not_reported_as_a_terminal_result():
+    moves = tuple(chess.Move.from_uci(uci) for uci in ("g1f3", "g8f6", "f3g1", "f6g8") * 2)
+
+    variation = analyze_variation(chess.Board(), moves, MaterialAnalyzer())
+
+    assert variation.final.history_complete
+    assert not variation.terminal.is_terminal
+    assert variation.terminal.result == "*"
+    assert variation.terminal.termination is None
+    assert variation.terminal.claimable_draw
 
 
 def test_refutation_intent_names_candidate_and_opponent_response():

--- a/tests/unit/test_move_evidence.py
+++ b/tests/unit/test_move_evidence.py
@@ -1,0 +1,279 @@
+"""Tests for exact move deltas and variation evidence."""
+
+from dataclasses import replace
+
+import chess
+import pytest
+
+from lczerolens.facts import (
+    AttacksDefendersAnalyzer,
+    AttacksDefendersValue,
+    CheckStatusAnalyzer,
+    FactPerspective,
+    MaterialAnalyzer,
+)
+from lczerolens.move_evidence import (
+    EvidenceTransition,
+    EvidenceTransitionKind,
+    ExactMoveEffect,
+    HistoryPolicy,
+    VariationAnalysisError,
+    VariationFailureReason,
+    VariationIntent,
+    VariationRole,
+    analyze_move_delta,
+    analyze_variation,
+    exact_move_analyzers,
+)
+
+
+def test_capture_changes_material_and_retains_move_and_position_provenance():
+    board = chess.Board("4k3/p7/8/8/8/8/8/R3K3 w - - 0 1")
+    move = chess.Move.from_uci("a1a7")
+    delta = analyze_move_delta(
+        board,
+        move,
+        MaterialAnalyzer(FactPerspective.WHITE),
+        MaterialAnalyzer(FactPerspective.BLACK),
+    )
+
+    assert delta.before.fen == board.fen()
+    assert delta.after.turn.value == "black"
+    assert delta.move.move == move
+    assert delta.move.captured_piece == chess.Piece(chess.PAWN, chess.BLACK)
+    assert delta.move.capture_square == chess.A7
+    assert delta.move.effects == (ExactMoveEffect.CAPTURE,)
+    assert delta.removed.items[0].value == 1
+    assert delta.created.items[0].value == 0
+    assert delta.preserved.items[0].value == 5
+    assert delta.changed[0].kind is EvidenceTransitionKind.CHANGED
+
+
+def test_check_and_evasion_are_exact_move_effects():
+    checking = chess.Board("4k3/8/8/8/8/8/R7/4K3 w - - 0 1")
+    check = analyze_move_delta(checking, chess.Move.from_uci("a2e2"), CheckStatusAnalyzer(FactPerspective.BLACK))
+    assert check.move.effects == (ExactMoveEffect.CHECK,)
+    assert check.created.items[0].value is True
+
+    evading = chess.Board("4k3/8/8/8/8/8/4R3/4K3 b - - 0 1")
+    evasion = analyze_move_delta(evading, chess.Move.from_uci("e8f8"), CheckStatusAnalyzer(FactPerspective.BLACK))
+    assert evasion.move.effects == (ExactMoveEffect.EVASION,)
+    assert evasion.created.items[0].value is False
+
+
+def test_discovered_attack_and_defender_removal_change_supporting_evidence():
+    discovered = chess.Board("r3k3/8/8/8/8/8/B7/R3K3 w - - 0 1")
+    attack = analyze_move_delta(
+        discovered,
+        chess.Move.from_uci("a2b3"),
+        AttacksDefendersAnalyzer(chess.A8, FactPerspective.BLACK),
+    )
+    assert attack.removed.items[0].value == AttacksDefendersValue(0, 0)
+    assert attack.created.items[0].value == AttacksDefendersValue(1, 0)
+    assert chess.A1 in attack.created.items[0].supporting_squares
+
+    defended = chess.Board("4k3/5n2/8/4P3/2N5/8/8/4K3 w - - 0 1")
+    defender = analyze_move_delta(
+        defended,
+        chess.Move.from_uci("c4b6"),
+        AttacksDefendersAnalyzer(chess.E5, FactPerspective.WHITE),
+    )
+    assert defender.removed.items[0].value == AttacksDefendersValue(1, 1)
+    assert defender.created.items[0].value == AttacksDefendersValue(1, 0)
+
+
+def test_equal_attack_counts_still_report_changed_attacker_identity():
+    board = chess.Board("r3k3/8/8/8/8/8/R7/R3K3 w - - 0 1")
+    delta = analyze_move_delta(
+        board,
+        chess.Move.from_uci("a2b2"),
+        AttacksDefendersAnalyzer(chess.A8, FactPerspective.BLACK),
+    )
+
+    assert delta.removed.items[0].value == delta.created.items[0].value == AttacksDefendersValue(1, 0)
+    assert delta.removed.items[0].supporting_pieces[0].square == chess.A2
+    assert delta.created.items[0].supporting_pieces[0].square == chess.A1
+    assert delta.changed[0].kind is EvidenceTransitionKind.CHANGED
+
+
+@pytest.mark.parametrize(
+    ("fen", "uci", "effects", "capture_square", "rook_uci"),
+    [
+        (
+            "4k3/P7/8/8/8/8/8/4K3 w - - 0 1",
+            "a7a8q",
+            (ExactMoveEffect.CHECK, ExactMoveEffect.PROMOTION),
+            None,
+            None,
+        ),
+        (
+            "4k3/8/8/8/8/8/8/R3K2R w KQ - 0 1",
+            "e1g1",
+            (ExactMoveEffect.CASTLING,),
+            None,
+            "h1f1",
+        ),
+        (
+            "4k3/8/8/8/8/8/8/R3K2R w KQ - 0 1",
+            "e1c1",
+            (ExactMoveEffect.CASTLING,),
+            None,
+            "a1d1",
+        ),
+        (
+            "4k3/8/8/3pP3/8/8/8/4K3 w - d6 0 1",
+            "e5d6",
+            (ExactMoveEffect.CAPTURE, ExactMoveEffect.EN_PASSANT),
+            chess.D5,
+            None,
+        ),
+        (
+            "4k3/8/8/8/3Pp3/8/8/4K3 b - d3 0 1",
+            "e4d3",
+            (ExactMoveEffect.CAPTURE, ExactMoveEffect.EN_PASSANT),
+            chess.D4,
+            None,
+        ),
+    ],
+)
+def test_special_moves_have_explicit_exact_metadata(fen, uci, effects, capture_square, rook_uci):
+    delta = analyze_move_delta(chess.Board(fen), chess.Move.from_uci(uci), MaterialAnalyzer())
+
+    assert delta.move.effects == effects
+    assert delta.move.capture_square == capture_square
+    assert (delta.move.rook_move.uci() if delta.move.rook_move else None) == rook_uci
+
+
+def test_unchanged_control_is_preserved_without_losing_original_evidence():
+    board = chess.Board()
+    before = MaterialAnalyzer(FactPerspective.WHITE).analyze(board)
+    delta = analyze_move_delta(board, chess.Move.from_uci("e2e4"), MaterialAnalyzer(FactPerspective.WHITE))
+
+    assert not delta.created.items
+    assert not delta.removed.items
+    assert delta.preserved.items == (before,)
+    assert delta.transitions[0].before == before
+    assert delta.transitions[0].after.value == before.value
+    assert delta.transitions[0].after.supporting_pieces != before.supporting_pieces
+    assert delta.transitions[0].kind is EvidenceTransitionKind.PRESERVED
+
+
+def test_default_suite_covers_both_sides_all_squares_and_mobility():
+    analyzers = exact_move_analyzers()
+    delta = analyze_move_delta(chess.Board(), chess.Move.from_uci("e2e4"))
+
+    assert len(analyzers) == 145
+    assert len(delta.before.evidence) == len(delta.after.evidence) == 145
+    assert delta.before.turn.value == "white"
+    assert delta.after.turn.value == "black"
+    assert delta.before.history_complete
+    assert delta.after.history_complete
+
+
+def test_transition_and_input_validation_rejects_inconsistent_records():
+    evidence = MaterialAnalyzer(FactPerspective.WHITE).analyze(chess.Board())
+    changed = replace(evidence, value=999)
+    with pytest.raises(ValueError, match="same fact identity and value"):
+        EvidenceTransition(evidence, changed, EvidenceTransitionKind.PRESERVED)
+    with pytest.raises(ValueError, match="different fact identity or value"):
+        EvidenceTransition(evidence, evidence, EvidenceTransitionKind.CHANGED)
+    with pytest.raises(TypeError, match="Move-delta analysis"):
+        analyze_move_delta("not a board", chess.Move.from_uci("e2e4"))
+    with pytest.raises(VariationAnalysisError) as illegal:
+        analyze_move_delta(chess.Board(), "not a move")
+    assert illegal.value.reason is VariationFailureReason.ILLEGAL_MOVE
+    assert illegal.value.move is None
+    with pytest.raises(TypeError, match="Variation analysis"):
+        analyze_variation("not a board", (chess.Move.from_uci("e2e4"),))
+    with pytest.raises(ValueError, match="history_policy"):
+        analyze_variation(chess.Board(), (chess.Move.from_uci("e2e4"),), history_policy="allow")
+
+
+def test_variation_tracks_alternating_perspective_terminal_result_and_intent():
+    board = chess.Board("7k/5Q2/6K1/8/8/8/8/8 w - - 0 1")
+    candidate = chess.Move.from_uci("f7g7")
+    intent = VariationIntent(
+        role=VariationRole.CANDIDATE_SUPPORT,
+        claim_id="mate-candidate",
+        candidate=candidate,
+    )
+    variation = analyze_variation(board, (candidate,), CheckStatusAnalyzer(), intent=intent)
+
+    assert variation.initial.turn.value == "white"
+    assert variation.final.turn.value == "black"
+    assert variation.initial.history_truncated
+    assert variation.moves == (candidate,)
+    assert variation.intent == intent
+    assert variation.terminal.is_terminal
+    assert variation.terminal.result == "1-0"
+    assert variation.terminal.winner.value == "white"
+    assert variation.terminal.termination is chess.Termination.CHECKMATE
+
+
+def test_refutation_intent_names_candidate_and_opponent_response():
+    candidate = chess.Move.from_uci("e2e4")
+    response = chess.Move.from_uci("e7e5")
+    intent = VariationIntent(
+        role=VariationRole.OPPONENT_REFUTATION,
+        claim_id="candidate-keeps-e5-empty",
+        candidate=candidate,
+        response=response,
+    )
+    variation = analyze_variation(chess.Board(), (candidate, response), MaterialAnalyzer(), intent=intent)
+
+    assert variation.intent.response == response
+    assert [delta.move.mover.value for delta in variation.deltas] == ["white", "black"]
+    assert variation.final.ply == 2
+
+
+def test_illegal_history_incompatible_and_intent_mismatch_fail_structurally():
+    with pytest.raises(VariationAnalysisError) as illegal:
+        analyze_variation(chess.Board(), (chess.Move.from_uci("e2e5"),), MaterialAnalyzer())
+    assert illegal.value.reason is VariationFailureReason.ILLEGAL_MOVE
+    assert illegal.value.ply_index == 0
+    assert illegal.value.move == chess.Move.from_uci("e2e5")
+    assert illegal.value.fen == chess.Board().fen()
+
+    truncated = chess.Board("4k3/8/8/8/8/8/4P3/4K3 w - - 0 1")
+    with pytest.raises(VariationAnalysisError) as history:
+        analyze_variation(
+            truncated,
+            (chess.Move.from_uci("e2e3"),),
+            MaterialAnalyzer(),
+            history_policy=HistoryPolicy.REQUIRE_COMPLETE,
+        )
+    assert history.value.reason is VariationFailureReason.HISTORY_INCOMPATIBLE
+
+    intent = VariationIntent(
+        role=VariationRole.CANDIDATE_SUPPORT,
+        claim_id="different-candidate",
+        candidate=chess.Move.from_uci("d2d4"),
+    )
+    with pytest.raises(VariationAnalysisError) as mismatch:
+        analyze_variation(chess.Board(), (chess.Move.from_uci("e2e4"),), MaterialAnalyzer(), intent=intent)
+    assert mismatch.value.reason is VariationFailureReason.INTENT_MISMATCH
+
+
+def test_empty_line_and_malformed_intents_are_rejected():
+    with pytest.raises(VariationAnalysisError) as empty:
+        analyze_variation(chess.Board(), (), MaterialAnalyzer())
+    assert empty.value.reason is VariationFailureReason.EMPTY_LINE
+    with pytest.raises(ValueError, match="cannot name"):
+        VariationIntent(claim_id="claim")
+    with pytest.raises(ValueError, match="VariationRole"):
+        VariationIntent(role="neutral")
+    with pytest.raises(ValueError, match="claim_id and candidate"):
+        VariationIntent(role=VariationRole.CANDIDATE_SUPPORT)
+    with pytest.raises(ValueError, match="does not take"):
+        VariationIntent(
+            role=VariationRole.CANDIDATE_SUPPORT,
+            claim_id="claim",
+            candidate=chess.Move.from_uci("e2e4"),
+            response=chess.Move.from_uci("e7e5"),
+        )
+    with pytest.raises(ValueError, match="needs the opponent response"):
+        VariationIntent(
+            role=VariationRole.OPPONENT_REFUTATION,
+            claim_id="claim",
+            candidate=chess.Move.from_uci("e2e4"),
+        )


### PR DESCRIPTION
## Summary

- add immutable `MoveDelta` records that retain before/after positions, exact move metadata, created/removed/preserved evidence sets, and linked fact transitions
- add a complete exact analyzer suite for material, checks, piece presence, attacks/defenders, and side-to-move mobility across both concrete sides
- add ordered `VariationEvidence` with explicit candidate-support/opponent-refutation intent, history policy, alternating-ply perspective, and terminal result metadata
- return structured failures for empty or illegal lines, incomplete required history, and declared candidate/response mismatches
- document the evidence-composition boundary and keep heuristic interpretations such as initiative and compensation out of the core API

## Impact

Consumers can now explain what legal moves and variations exactly change or preserve without depending on a neural model, search implementation, interpretability framework, or natural-language generator. Every delta retains its source positions, legal move, concrete mover, supporting chess objects, and analyzer provenance.

## Validation

- `just tests` — 204 passed, 12 deselected; 86.78% total coverage
- focused move-evidence suite — 16 passed; 100% line and branch coverage for `move_evidence.py`
- `uv run --group dev pre-commit run --all-files`
- `just docs` — succeeded with 42 existing AutoAPI/cross-reference warnings
- `git diff --check`

Closes #142