### PR TITLE
Add constraint-aware chess counterfactuals

### DIFF
--- a/docs/source/facts.rst
+++ b/docs/source/facts.rst
@@ -86,3 +86,47 @@ compensation. Terminal result metadata uses rule-exact ``python-chess``
 outcomes. ``VariationTerminal.claimable_draw`` separately records a threefold
 or fifty-move draw that can be claimed when complete history is available; it
 does not turn a legally continuable position into a terminal result.
+
+Constraint-aware counterfactuals
+--------------------------------
+
+``lczerolens.counterfactuals`` creates position pairs without treating every
+board edit as a reachable game state. ``sibling_counterfactual`` compares a
+factual legal move with a different legal move from the same parent. If the
+parent has a complete standard-game move stack, both children receive the
+``history_consistent`` tier; otherwise the result records only the
+``sibling_legal_move`` guarantee. Omitting the alternative selects the first
+satisfying legal move in stable UCI order.
+
+``remove_piece_counterfactual`` and ``relocate_piece_counterfactual`` are
+structural operators. They reject king edits, occupied relocation targets, and
+invalid resulting positions. They normalize affected castling and en-passant
+metadata and can establish only ``rule_valid``. They always state that
+historical reachability is unproven.
+
+Constraints independently request changed or preserved turn, kings, material,
+castling rights, en-passant square, halfmove clock, and complete-history
+availability. Every successful result also reports the observed relation for
+all seven attributes, including unconstrained metadata. Fact constraints accept
+any ``FactAnalyzer`` and retain the original and modified ``Evidence`` records
+in ``FactVerification``. A request that cannot be met returns
+``CounterfactualResult.succeeded == False`` with
+stable ``CounterfactualFailureReason`` values instead of a malformed or
+mischaracterized position.
+
+For example, removing White's a1 rook can require changed material and castling
+rights while preserving turn and kings::
+
+   constraints = CounterfactualConstraints(
+       changed_attributes=frozenset({
+           PositionAttribute.MATERIAL,
+           PositionAttribute.CASTLING_RIGHTS,
+       }),
+       preserved_attributes=frozenset({
+           PositionAttribute.TURN,
+           PositionAttribute.KINGS,
+       }),
+   )
+   result = remove_piece_counterfactual(chess.Board(), chess.A1, constraints=constraints)
+   assert result.validity is CounterfactualValidity.RULE_VALID
+   assert not result.history.reachability_proven

--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -3,6 +3,15 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .board import LczeroBoard
+from .counterfactuals import (
+    CounterfactualConstraints,
+    CounterfactualResult,
+    CounterfactualValidity,
+    PositionAttribute,
+    relocate_piece_counterfactual,
+    remove_piece_counterfactual,
+    sibling_counterfactual,
+)
 from .facts import Evidence, EvidenceSet, FactAnalyzer
 from .lc0_adapter import Lc0ProcessAdapter, Lc0RootSnapshotParser, Lc0SearchRequest
 from .model import LczeroModel
@@ -17,6 +26,9 @@ except PackageNotFoundError:
 __all__ = [
     "LczeroBoard",
     "LczeroModel",
+    "CounterfactualConstraints",
+    "CounterfactualResult",
+    "CounterfactualValidity",
     "Evidence",
     "EvidenceSet",
     "FactAnalyzer",
@@ -24,9 +36,13 @@ __all__ = [
     "Lc0RootSnapshotParser",
     "Lc0SearchRequest",
     "MoveDelta",
+    "PositionAttribute",
     "ReferenceMCTS",
     "VariationEvidence",
     "analyze_move_delta",
     "analyze_variation",
+    "relocate_piece_counterfactual",
+    "remove_piece_counterfactual",
     "replay_root_events",
+    "sibling_counterfactual",
 ]

--- a/src/lczerolens/counterfactuals.py
+++ b/src/lczerolens/counterfactuals.py
@@ -219,12 +219,12 @@ def sibling_counterfactual(
     resolved = constraints or CounterfactualConstraints()
     operator = SiblingMoveOperator(factual_move, alternative_move)
     parent_snapshot = _snapshot(parent)
-    empty_history = _history_guarantee(parent, None, shared_parent=True, legal=True)
+    failure_history = _history_guarantee(parent, None, shared_parent=False, legal=False)
     if not parent.is_valid():
         return _failure_result(
             parent_snapshot,
             operator,
-            empty_history,
+            failure_history,
             CounterfactualFailureReason.INVALID_POSITION,
             f"The supplied parent position has invalid python-chess status {int(parent.status())}.",
         )
@@ -232,7 +232,7 @@ def sibling_counterfactual(
         return _failure_result(
             parent_snapshot,
             operator,
-            empty_history,
+            failure_history,
             CounterfactualFailureReason.ILLEGAL_FACTUAL_MOVE,
             "The factual move is not legal in the supplied parent position.",
             candidate_move=factual_move if isinstance(factual_move, chess.Move) else None,
@@ -284,19 +284,19 @@ def sibling_counterfactual(
             modified_move_delta=analyze_move_delta(parent, candidate),
         )
 
-    if alternative_move is not None and candidate_failures:
-        reason = candidate_failures[0].reason
-        message = candidate_failures[0].message
+    if alternative_move is not None:
+        failures = tuple(candidate_failures)
     else:
         reason = CounterfactualFailureReason.NO_SATISFYING_COUNTERFACTUAL
         message = f"None of {len(candidates)} deterministic legal alternatives satisfied the constraints."
+        failures = (CounterfactualFailure(reason, message), *candidate_failures)
     return CounterfactualResult(
         original=original,
         modified=None,
         operator=operator,
         validity=CounterfactualValidity.NO_COUNTERFACTUAL,
         history=_history_guarantee(factual_board, None, shared_parent=True, legal=True),
-        failures=(CounterfactualFailure(reason, message), *tuple(candidate_failures)),
+        failures=failures,
     )
 
 

--- a/src/lczerolens/counterfactuals.py
+++ b/src/lczerolens/counterfactuals.py
@@ -1,0 +1,659 @@
+"""Constraint-aware chess counterfactuals with explicit validity tiers.
+
+Sibling counterfactuals replay two legal moves from one parent. Structural
+counterfactuals edit a position directly and can establish rule validity, but
+never historical reachability.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TypeAlias
+
+import chess
+
+from .facts import Evidence, FactAnalyzer, FactKind, HistoryRequirement, history_is_available
+from .move_evidence import MoveDelta, analyze_move_delta
+
+
+class CounterfactualValidity(str, Enum):
+    """Strongest validity claim established for a result."""
+
+    NO_COUNTERFACTUAL = "no_counterfactual"
+    RULE_VALID = "rule_valid"
+    SIBLING_LEGAL_MOVE = "sibling_legal_move"
+    HISTORY_CONSISTENT = "history_consistent"
+
+
+class PositionAttribute(str, Enum):
+    """Rule or metadata attributes that constraints can compare."""
+
+    TURN = "turn"
+    KINGS = "kings"
+    MATERIAL = "material"
+    CASTLING_RIGHTS = "castling_rights"
+    EN_PASSANT = "en_passant"
+    HALFMOVE_CLOCK = "halfmove_clock"
+    HISTORY = "history"
+
+
+class ConstraintRelation(str, Enum):
+    """Requested relation between original and modified positions."""
+
+    CHANGED = "changed"
+    PRESERVED = "preserved"
+
+
+class CounterfactualFailureReason(str, Enum):
+    """Stable reasons why no counterfactual was produced."""
+
+    ILLEGAL_FACTUAL_MOVE = "illegal_factual_move"
+    ILLEGAL_ALTERNATIVE_MOVE = "illegal_alternative_move"
+    NO_ALTERNATIVE = "no_alternative"
+    NO_SATISFYING_COUNTERFACTUAL = "no_satisfying_counterfactual"
+    EMPTY_SOURCE_SQUARE = "empty_source_square"
+    OCCUPIED_TARGET_SQUARE = "occupied_target_square"
+    KING_EDIT_FORBIDDEN = "king_edit_forbidden"
+    INVALID_POSITION = "invalid_position"
+    CONSTRAINT_VIOLATION = "constraint_violation"
+
+
+@dataclass(frozen=True)
+class SiblingMoveOperator:
+    """Replace one legal move with another legal move from the same parent."""
+
+    factual_move: chess.Move
+    alternative_move: chess.Move | None = None
+
+
+@dataclass(frozen=True)
+class RemovePieceOperator:
+    """Remove the non-king piece on ``square``."""
+
+    square: chess.Square
+
+    def __post_init__(self) -> None:
+        _validate_square(self.square)
+
+
+@dataclass(frozen=True)
+class RelocatePieceOperator:
+    """Relocate a non-king piece to an empty square without making a move."""
+
+    from_square: chess.Square
+    to_square: chess.Square
+
+    def __post_init__(self) -> None:
+        _validate_square(self.from_square)
+        _validate_square(self.to_square)
+        if self.from_square == self.to_square:
+            raise ValueError("Relocation source and target squares must differ.")
+
+
+CounterfactualOperator: TypeAlias = SiblingMoveOperator | RemovePieceOperator | RelocatePieceOperator
+
+
+@dataclass(frozen=True)
+class CounterfactualConstraints:
+    """Metadata and evidence-bearing fact relations a result must satisfy."""
+
+    changed_attributes: frozenset[PositionAttribute] = frozenset()
+    preserved_attributes: frozenset[PositionAttribute] = frozenset()
+    changed_facts: tuple[FactAnalyzer, ...] = ()
+    preserved_facts: tuple[FactAnalyzer, ...] = ()
+
+    def __post_init__(self) -> None:
+        overlap = self.changed_attributes & self.preserved_attributes
+        if overlap:
+            labels = ", ".join(sorted(item.value for item in overlap))
+            raise ValueError(f"Attributes cannot be both changed and preserved: {labels}.")
+        for attribute in self.changed_attributes | self.preserved_attributes:
+            if not isinstance(attribute, PositionAttribute):
+                raise ValueError("Attribute constraints must use PositionAttribute values.")
+        for analyzer in (*self.changed_facts, *self.preserved_facts):
+            if not isinstance(analyzer, FactAnalyzer):
+                raise TypeError("Fact constraints must implement FactAnalyzer.")
+
+
+@dataclass(frozen=True)
+class CounterfactualPosition:
+    """Serializable position identity plus rule and history status."""
+
+    fen: str
+    status: chess.Status
+    rule_valid: bool
+    history_complete: bool
+
+
+@dataclass(frozen=True)
+class HistoryGuarantee:
+    """What is known about the relationship between the position histories."""
+
+    original_complete: bool
+    modified_complete: bool
+    shared_parent: bool
+    legal_from_shared_parent: bool
+    reachability_proven: bool
+
+
+@dataclass(frozen=True)
+class AttributeVerification:
+    """Observed values and outcome for one requested metadata constraint."""
+
+    attribute: PositionAttribute
+    relation: ConstraintRelation
+    original: object
+    modified: object
+    satisfied: bool
+
+
+@dataclass(frozen=True)
+class AttributeChange:
+    """Observed relation for one metadata attribute, whether constrained or not."""
+
+    attribute: PositionAttribute
+    original: object
+    modified: object
+    changed: bool
+
+
+@dataclass(frozen=True)
+class FactVerification:
+    """Original evidence and modified evidence for one requested fact relation."""
+
+    relation: ConstraintRelation
+    original: Evidence
+    modified: Evidence
+    satisfied: bool
+
+
+@dataclass(frozen=True)
+class CounterfactualFailure:
+    """One machine-readable failure with optional candidate context."""
+
+    reason: CounterfactualFailureReason
+    message: str
+    candidate_move: chess.Move | None = None
+    attribute: PositionAttribute | None = None
+    analyzer: str | None = None
+
+
+@dataclass(frozen=True)
+class CounterfactualResult:
+    """A successful intervention or structured explanation of its failure."""
+
+    original: CounterfactualPosition
+    modified: CounterfactualPosition | None
+    operator: CounterfactualOperator
+    validity: CounterfactualValidity
+    history: HistoryGuarantee
+    attributes: tuple[AttributeChange, ...] = ()
+    changed_attributes: tuple[AttributeVerification, ...] = ()
+    preserved_attributes: tuple[AttributeVerification, ...] = ()
+    changed_facts: tuple[FactVerification, ...] = ()
+    preserved_facts: tuple[FactVerification, ...] = ()
+    original_move_delta: MoveDelta | None = None
+    modified_move_delta: MoveDelta | None = None
+    failures: tuple[CounterfactualFailure, ...] = ()
+
+    @property
+    def succeeded(self) -> bool:
+        """Whether a satisfying, valid modified position was produced."""
+        return self.modified is not None and not self.failures
+
+
+def sibling_counterfactual(
+    parent: chess.Board,
+    factual_move: chess.Move,
+    alternative_move: chess.Move | None = None,
+    *,
+    constraints: CounterfactualConstraints | None = None,
+) -> CounterfactualResult:
+    """Compare two legal children of one parent, choosing deterministically.
+
+    When ``alternative_move`` is omitted, legal alternatives are tried in UCI
+    order and the first one satisfying all constraints is returned.
+    """
+    _validate_board(parent)
+    resolved = constraints or CounterfactualConstraints()
+    operator = SiblingMoveOperator(factual_move, alternative_move)
+    parent_snapshot = _snapshot(parent)
+    empty_history = _history_guarantee(parent, None, shared_parent=True, legal=True)
+    if not parent.is_valid():
+        return _failure_result(
+            parent_snapshot,
+            operator,
+            empty_history,
+            CounterfactualFailureReason.INVALID_POSITION,
+            f"The supplied parent position has invalid python-chess status {int(parent.status())}.",
+        )
+    if not _is_legal_move(parent, factual_move):
+        return _failure_result(
+            parent_snapshot,
+            operator,
+            empty_history,
+            CounterfactualFailureReason.ILLEGAL_FACTUAL_MOVE,
+            "The factual move is not legal in the supplied parent position.",
+            candidate_move=factual_move if isinstance(factual_move, chess.Move) else None,
+        )
+
+    factual_board = parent.copy(stack=True)
+    factual_board.push(factual_move)
+    original = _snapshot(factual_board)
+    candidates = (
+        (alternative_move,)
+        if alternative_move is not None
+        else tuple(sorted((move for move in parent.legal_moves if move != factual_move), key=lambda move: move.uci()))
+    )
+    if not candidates:
+        return _failure_result(
+            original,
+            operator,
+            _history_guarantee(factual_board, None, shared_parent=True, legal=True),
+            CounterfactualFailureReason.NO_ALTERNATIVE,
+            "The parent position has no legal move other than the factual move.",
+        )
+
+    candidate_failures: list[CounterfactualFailure] = []
+    for candidate in candidates:
+        if not _is_legal_move(parent, candidate) or candidate == factual_move:
+            candidate_failures.append(
+                CounterfactualFailure(
+                    CounterfactualFailureReason.ILLEGAL_ALTERNATIVE_MOVE,
+                    "The alternative must be a different legal move from the same parent.",
+                    candidate_move=candidate if isinstance(candidate, chess.Move) else None,
+                )
+            )
+            continue
+        modified_board = parent.copy(stack=True)
+        modified_board.push(candidate)
+        verifications, failures = _verify_constraints(factual_board, modified_board, resolved, candidate)
+        if failures:
+            candidate_failures.extend(failures)
+            continue
+        complete = history_is_available(modified_board, HistoryRequirement.FULL_MOVE_STACK)
+        return _success_result(
+            factual_board,
+            modified_board,
+            SiblingMoveOperator(factual_move, candidate),
+            CounterfactualValidity.HISTORY_CONSISTENT if complete else CounterfactualValidity.SIBLING_LEGAL_MOVE,
+            _history_guarantee(factual_board, modified_board, shared_parent=True, legal=True),
+            verifications,
+            original_move_delta=analyze_move_delta(parent, factual_move),
+            modified_move_delta=analyze_move_delta(parent, candidate),
+        )
+
+    if alternative_move is not None and candidate_failures:
+        reason = candidate_failures[0].reason
+        message = candidate_failures[0].message
+    else:
+        reason = CounterfactualFailureReason.NO_SATISFYING_COUNTERFACTUAL
+        message = f"None of {len(candidates)} deterministic legal alternatives satisfied the constraints."
+    return CounterfactualResult(
+        original=original,
+        modified=None,
+        operator=operator,
+        validity=CounterfactualValidity.NO_COUNTERFACTUAL,
+        history=_history_guarantee(factual_board, None, shared_parent=True, legal=True),
+        failures=(CounterfactualFailure(reason, message), *tuple(candidate_failures)),
+    )
+
+
+def remove_piece_counterfactual(
+    board: chess.Board,
+    square: chess.Square,
+    *,
+    constraints: CounterfactualConstraints | None = None,
+) -> CounterfactualResult:
+    """Remove a non-king piece and return a rule-valid structural state."""
+    _validate_board(board)
+    operator = RemovePieceOperator(square)
+    if not board.is_valid():
+        return _structural_failure(
+            board,
+            operator,
+            CounterfactualFailureReason.INVALID_POSITION,
+            f"The supplied position has invalid python-chess status {int(board.status())}.",
+        )
+    piece = board.piece_at(square)
+    if piece is None:
+        return _structural_failure(
+            board, operator, CounterfactualFailureReason.EMPTY_SOURCE_SQUARE, "No piece exists on the source square."
+        )
+    if piece.piece_type == chess.KING:
+        return _structural_failure(
+            board,
+            operator,
+            CounterfactualFailureReason.KING_EDIT_FORBIDDEN,
+            "Structural operators cannot remove a king.",
+        )
+    modified = board.copy(stack=False)
+    modified.remove_piece_at(square)
+    _normalize_structural_metadata(modified)
+    return _finish_structural(board, modified, operator, constraints or CounterfactualConstraints())
+
+
+def relocate_piece_counterfactual(
+    board: chess.Board,
+    from_square: chess.Square,
+    to_square: chess.Square,
+    *,
+    constraints: CounterfactualConstraints | None = None,
+) -> CounterfactualResult:
+    """Relocate a non-king piece and return a rule-valid structural state."""
+    _validate_board(board)
+    operator = RelocatePieceOperator(from_square, to_square)
+    if not board.is_valid():
+        return _structural_failure(
+            board,
+            operator,
+            CounterfactualFailureReason.INVALID_POSITION,
+            f"The supplied position has invalid python-chess status {int(board.status())}.",
+        )
+    piece = board.piece_at(from_square)
+    if piece is None:
+        return _structural_failure(
+            board, operator, CounterfactualFailureReason.EMPTY_SOURCE_SQUARE, "No piece exists on the source square."
+        )
+    if board.piece_at(to_square) is not None:
+        return _structural_failure(
+            board, operator, CounterfactualFailureReason.OCCUPIED_TARGET_SQUARE, "The relocation target must be empty."
+        )
+    if piece.piece_type == chess.KING:
+        return _structural_failure(
+            board,
+            operator,
+            CounterfactualFailureReason.KING_EDIT_FORBIDDEN,
+            "Structural operators cannot relocate a king.",
+        )
+    modified = board.copy(stack=False)
+    modified.remove_piece_at(from_square)
+    modified.set_piece_at(to_square, piece, promoted=bool(board.promoted & chess.BB_SQUARES[from_square]))
+    _normalize_structural_metadata(modified)
+    return _finish_structural(board, modified, operator, constraints or CounterfactualConstraints())
+
+
+def _finish_structural(
+    original: chess.Board,
+    modified: chess.Board,
+    operator: CounterfactualOperator,
+    constraints: CounterfactualConstraints,
+) -> CounterfactualResult:
+    history = _history_guarantee(original, modified, shared_parent=False, legal=False)
+    if not modified.is_valid():
+        return _failure_result(
+            _snapshot(original),
+            operator,
+            history,
+            CounterfactualFailureReason.INVALID_POSITION,
+            f"The structural edit produced invalid python-chess status {int(modified.status())}.",
+        )
+    verifications, failures = _verify_constraints(original, modified, constraints)
+    if failures:
+        return CounterfactualResult(
+            original=_snapshot(original),
+            modified=None,
+            operator=operator,
+            validity=CounterfactualValidity.NO_COUNTERFACTUAL,
+            history=history,
+            attributes=_compare_attributes(original, modified),
+            changed_attributes=verifications[0],
+            preserved_attributes=verifications[1],
+            changed_facts=verifications[2],
+            preserved_facts=verifications[3],
+            failures=failures,
+        )
+    return _success_result(
+        original,
+        modified,
+        operator,
+        CounterfactualValidity.RULE_VALID,
+        history,
+        verifications,
+    )
+
+
+VerificationGroups: TypeAlias = tuple[
+    tuple[AttributeVerification, ...],
+    tuple[AttributeVerification, ...],
+    tuple[FactVerification, ...],
+    tuple[FactVerification, ...],
+]
+
+
+def _verify_constraints(
+    original: chess.Board,
+    modified: chess.Board,
+    constraints: CounterfactualConstraints,
+    candidate_move: chess.Move | None = None,
+) -> tuple[VerificationGroups, tuple[CounterfactualFailure, ...]]:
+    changed_attributes = tuple(
+        _verify_attribute(original, modified, attribute, ConstraintRelation.CHANGED)
+        for attribute in sorted(constraints.changed_attributes, key=lambda item: item.value)
+    )
+    preserved_attributes = tuple(
+        _verify_attribute(original, modified, attribute, ConstraintRelation.PRESERVED)
+        for attribute in sorted(constraints.preserved_attributes, key=lambda item: item.value)
+    )
+    changed_facts = tuple(
+        _verify_fact(original, modified, analyzer, ConstraintRelation.CHANGED)
+        for analyzer in constraints.changed_facts
+    )
+    preserved_facts = tuple(
+        _verify_fact(original, modified, analyzer, ConstraintRelation.PRESERVED)
+        for analyzer in constraints.preserved_facts
+    )
+    failures: list[CounterfactualFailure] = []
+    for verification in (*changed_attributes, *preserved_attributes):
+        if not verification.satisfied:
+            failures.append(
+                CounterfactualFailure(
+                    CounterfactualFailureReason.CONSTRAINT_VIOLATION,
+                    f"Attribute {verification.attribute.value} was not {verification.relation.value}.",
+                    candidate_move=candidate_move,
+                    attribute=verification.attribute,
+                )
+            )
+    for verification in (*changed_facts, *preserved_facts):
+        if not verification.satisfied:
+            failures.append(
+                CounterfactualFailure(
+                    CounterfactualFailureReason.CONSTRAINT_VIOLATION,
+                    f"Fact {verification.original.provenance.analyzer} was not {verification.relation.value}.",
+                    candidate_move=candidate_move,
+                    analyzer=verification.original.provenance.analyzer,
+                )
+            )
+    return (changed_attributes, preserved_attributes, changed_facts, preserved_facts), tuple(failures)
+
+
+def _verify_attribute(
+    original: chess.Board,
+    modified: chess.Board,
+    attribute: PositionAttribute,
+    relation: ConstraintRelation,
+) -> AttributeVerification:
+    before = _attribute_value(original, attribute)
+    after = _attribute_value(modified, attribute)
+    equal = before == after
+    return AttributeVerification(
+        attribute, relation, before, after, equal is (relation is ConstraintRelation.PRESERVED)
+    )
+
+
+def _verify_fact(
+    original: chess.Board,
+    modified: chess.Board,
+    analyzer: FactAnalyzer,
+    relation: ConstraintRelation,
+) -> FactVerification:
+    before = analyzer.analyze(original)
+    after = analyzer.analyze(modified)
+    equal = _same_evidence(before, after)
+    return FactVerification(relation, before, after, equal is (relation is ConstraintRelation.PRESERVED))
+
+
+def _compare_attributes(original: chess.Board, modified: chess.Board) -> tuple[AttributeChange, ...]:
+    comparisons: list[AttributeChange] = []
+    for attribute in PositionAttribute:
+        before = _attribute_value(original, attribute)
+        after = _attribute_value(modified, attribute)
+        comparisons.append(AttributeChange(attribute, before, after, before != after))
+    return tuple(comparisons)
+
+
+def _same_evidence(original: Evidence, modified: Evidence) -> bool:
+    same_value = (
+        original.kind == modified.kind
+        and original.scope == modified.scope
+        and original.subject == modified.subject
+        and original.value == modified.value
+        and original.perspective == modified.perspective
+        and original.guarantee == modified.guarantee
+        and original.provenance == modified.provenance
+        and original.history_requirement == modified.history_requirement
+        and original.history_available == modified.history_available
+        and original.undefined_reason == modified.undefined_reason
+    )
+    if not same_value:
+        return False
+    if original.kind in (FactKind.ATTACKS_DEFENDERS, FactKind.CHECK_STATUS):
+        return (
+            original.supporting_pieces == modified.supporting_pieces
+            and original.supporting_squares == modified.supporting_squares
+        )
+    return True
+
+
+def _attribute_value(board: chess.Board, attribute: PositionAttribute) -> object:
+    if attribute is PositionAttribute.TURN:
+        return board.turn
+    if attribute is PositionAttribute.KINGS:
+        return (board.king(chess.WHITE), board.king(chess.BLACK))
+    if attribute is PositionAttribute.MATERIAL:
+        return tuple(
+            len(board.pieces(piece_type, color)) for color in chess.COLORS for piece_type in chess.PIECE_TYPES
+        )
+    if attribute is PositionAttribute.CASTLING_RIGHTS:
+        return board.castling_rights
+    if attribute is PositionAttribute.EN_PASSANT:
+        return board.ep_square
+    if attribute is PositionAttribute.HALFMOVE_CLOCK:
+        return board.halfmove_clock
+    if attribute is PositionAttribute.HISTORY:
+        return history_is_available(board, HistoryRequirement.FULL_MOVE_STACK)
+    raise AssertionError(f"Unhandled position attribute: {attribute!r}.")
+
+
+def _success_result(
+    original: chess.Board,
+    modified: chess.Board,
+    operator: CounterfactualOperator,
+    validity: CounterfactualValidity,
+    history: HistoryGuarantee,
+    verifications: VerificationGroups,
+    *,
+    original_move_delta: MoveDelta | None = None,
+    modified_move_delta: MoveDelta | None = None,
+) -> CounterfactualResult:
+    return CounterfactualResult(
+        original=_snapshot(original),
+        modified=_snapshot(modified),
+        operator=operator,
+        validity=validity,
+        history=history,
+        attributes=_compare_attributes(original, modified),
+        changed_attributes=verifications[0],
+        preserved_attributes=verifications[1],
+        changed_facts=verifications[2],
+        preserved_facts=verifications[3],
+        original_move_delta=original_move_delta,
+        modified_move_delta=modified_move_delta,
+    )
+
+
+def _failure_result(
+    original: CounterfactualPosition,
+    operator: CounterfactualOperator,
+    history: HistoryGuarantee,
+    reason: CounterfactualFailureReason,
+    message: str,
+    *,
+    candidate_move: chess.Move | None = None,
+) -> CounterfactualResult:
+    return CounterfactualResult(
+        original=original,
+        modified=None,
+        operator=operator,
+        validity=CounterfactualValidity.NO_COUNTERFACTUAL,
+        history=history,
+        failures=(CounterfactualFailure(reason, message, candidate_move=candidate_move),),
+    )
+
+
+def _structural_failure(
+    board: chess.Board,
+    operator: CounterfactualOperator,
+    reason: CounterfactualFailureReason,
+    message: str,
+) -> CounterfactualResult:
+    return _failure_result(
+        _snapshot(board),
+        operator,
+        _history_guarantee(board, None, shared_parent=False, legal=False),
+        reason,
+        message,
+    )
+
+
+def _snapshot(board: chess.Board) -> CounterfactualPosition:
+    return CounterfactualPosition(
+        fen=board.fen(en_passant="fen"),
+        status=board.status(),
+        rule_valid=board.is_valid(),
+        history_complete=history_is_available(board, HistoryRequirement.FULL_MOVE_STACK),
+    )
+
+
+def _history_guarantee(
+    original: chess.Board,
+    modified: chess.Board | None,
+    *,
+    shared_parent: bool,
+    legal: bool,
+) -> HistoryGuarantee:
+    original_complete = history_is_available(original, HistoryRequirement.FULL_MOVE_STACK)
+    modified_complete = modified is not None and history_is_available(modified, HistoryRequirement.FULL_MOVE_STACK)
+    return HistoryGuarantee(
+        original_complete=original_complete,
+        modified_complete=modified_complete,
+        shared_parent=shared_parent,
+        legal_from_shared_parent=legal,
+        reachability_proven=original_complete and modified_complete and shared_parent and legal,
+    )
+
+
+def _normalize_structural_metadata(board: chess.Board) -> None:
+    board.castling_rights = board.clean_castling_rights()
+    if board.status() & chess.STATUS_INVALID_EP_SQUARE:
+        board.ep_square = None
+
+
+def _validate_board(board: chess.Board) -> None:
+    if not isinstance(board, chess.Board):
+        raise TypeError("Counterfactual generation requires a python-chess Board.")
+
+
+def _validate_square(square: chess.Square) -> None:
+    if not isinstance(square, int) or isinstance(square, bool) or square not in chess.SQUARES:
+        raise ValueError(f"Invalid chess square: {square!r}.")
+
+
+def _is_legal_move(board: chess.Board, move: object) -> bool:
+    return (
+        isinstance(move, chess.Move)
+        and move.from_square in chess.SQUARES
+        and move.to_square in chess.SQUARES
+        and move in board.legal_moves
+    )

--- a/tests/unit/test_counterfactuals.py
+++ b/tests/unit/test_counterfactuals.py
@@ -3,6 +3,8 @@
 import chess
 import pytest
 
+import lczerolens.counterfactuals as counterfactuals
+
 from lczerolens.counterfactuals import (
     ConstraintRelation,
     CounterfactualConstraints,
@@ -238,6 +240,9 @@ def test_invalid_source_positions_and_malformed_configuration_are_rejected():
     relocation = relocate_piece_counterfactual(invalid, chess.E2, chess.E3)
 
     assert sibling.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
+    assert not sibling.history.shared_parent
+    assert not sibling.history.legal_from_shared_parent
+    assert not sibling.history.reachability_proven
     assert removal.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
     assert relocation.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
     with pytest.raises(TypeError, match="python-chess Board"):
@@ -255,6 +260,8 @@ def test_invalid_source_positions_and_malformed_configuration_are_rejected():
         CounterfactualConstraints(changed_attributes=frozenset(("turn",)))
     with pytest.raises(TypeError, match="FactAnalyzer"):
         CounterfactualConstraints(changed_facts=("material",))
+    with pytest.raises(AssertionError, match="Unhandled position attribute"):
+        counterfactuals._attribute_value(chess.Board(), object())
 
 
 def test_sibling_failures_distinguish_illegal_moves_and_no_alternative():
@@ -267,7 +274,10 @@ def test_sibling_failures_distinguish_illegal_moves_and_no_alternative():
     no_alternative = sibling_counterfactual(forced, only_move)
 
     assert illegal_factual.failures[0].reason is CounterfactualFailureReason.ILLEGAL_FACTUAL_MOVE
+    assert not illegal_factual.history.shared_parent
+    assert not illegal_factual.history.legal_from_shared_parent
     assert illegal_alternative.failures[0].reason is CounterfactualFailureReason.ILLEGAL_ALTERNATIVE_MOVE
+    assert len(illegal_alternative.failures) == 1
     assert no_alternative.failures[0].reason is CounterfactualFailureReason.NO_ALTERNATIVE
 
 

--- a/tests/unit/test_counterfactuals.py
+++ b/tests/unit/test_counterfactuals.py
@@ -1,0 +1,302 @@
+"""Tests for constraint-aware chess counterfactuals."""
+
+import chess
+import pytest
+
+from lczerolens.counterfactuals import (
+    ConstraintRelation,
+    CounterfactualConstraints,
+    CounterfactualFailureReason,
+    CounterfactualValidity,
+    PositionAttribute,
+    RelocatePieceOperator,
+    RemovePieceOperator,
+    SiblingMoveOperator,
+    relocate_piece_counterfactual,
+    remove_piece_counterfactual,
+    sibling_counterfactual,
+)
+from lczerolens.facts import AttacksDefendersAnalyzer, FactPerspective, MaterialAnalyzer
+
+
+def test_sibling_moves_are_deterministic_history_consistent_and_evidence_bearing():
+    parent = chess.Board()
+    constraints = CounterfactualConstraints(
+        changed_attributes=frozenset((PositionAttribute.EN_PASSANT,)),
+        preserved_attributes=frozenset(
+            (PositionAttribute.TURN, PositionAttribute.KINGS, PositionAttribute.MATERIAL, PositionAttribute.HISTORY)
+        ),
+        preserved_facts=(MaterialAnalyzer(FactPerspective.WHITE),),
+        changed_facts=(AttacksDefendersAnalyzer(chess.E3, FactPerspective.WHITE),),
+    )
+
+    result = sibling_counterfactual(
+        parent,
+        chess.Move.from_uci("e2e4"),
+        chess.Move.from_uci("d2d4"),
+        constraints=constraints,
+    )
+
+    assert result.succeeded
+    assert result.validity is CounterfactualValidity.HISTORY_CONSISTENT
+    assert result.history.reachability_proven
+    assert result.history.shared_parent
+    assert result.history.legal_from_shared_parent
+    assert result.modified is not None
+    assert result.modified.rule_valid
+    assert result.modified.history_complete
+    assert result.original.fen == "rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1"
+    assert result.modified.fen == "rnbqkbnr/pppppppp/8/8/3P4/8/PPP1PPPP/RNBQKBNR b KQkq d3 0 1"
+    assert result.changed_attributes[0].satisfied
+    assert all(item.satisfied for item in result.preserved_attributes)
+    assert result.preserved_facts[0].original.value == result.preserved_facts[0].modified.value == 39
+    assert result.changed_facts[0].original.value == result.changed_facts[0].modified.value
+    assert result.changed_facts[0].original.supporting_pieces != result.changed_facts[0].modified.supporting_pieces
+    assert result.original_move_delta is not None
+    assert result.original_move_delta.move.move == chess.Move.from_uci("e2e4")
+    assert result.modified_move_delta is not None
+    assert result.modified_move_delta.move.move == chess.Move.from_uci("d2d4")
+
+
+def test_automatic_sibling_selection_uses_uci_order_and_skips_unsatisfied_candidates():
+    result = sibling_counterfactual(
+        chess.Board(),
+        chess.Move.from_uci("e2e4"),
+        constraints=CounterfactualConstraints(
+            changed_facts=(MaterialAnalyzer(FactPerspective.WHITE),),
+        ),
+    )
+
+    assert not result.succeeded
+    assert result.validity is CounterfactualValidity.NO_COUNTERFACTUAL
+    assert result.failures[0].reason is CounterfactualFailureReason.NO_SATISFYING_COUNTERFACTUAL
+    assert result.failures[0].message.startswith("None of 19 deterministic legal alternatives")
+    assert all(failure.reason is CounterfactualFailureReason.CONSTRAINT_VIOLATION for failure in result.failures[1:])
+    candidates = tuple(failure.candidate_move.uci() for failure in result.failures[1:])
+    assert candidates == tuple(sorted(candidates))
+
+
+def test_automatic_sibling_selection_returns_first_uci_alternative():
+    result = sibling_counterfactual(chess.Board(), chess.Move.from_uci("e2e4"))
+
+    assert result.succeeded
+    assert isinstance(result.operator, SiblingMoveOperator)
+    assert result.operator.alternative_move == chess.Move.from_uci("a2a3")
+
+
+def test_structural_removal_reports_metadata_and_cannot_claim_reachability():
+    constraints = CounterfactualConstraints(
+        changed_attributes=frozenset((PositionAttribute.MATERIAL, PositionAttribute.CASTLING_RIGHTS)),
+        preserved_attributes=frozenset(
+            (
+                PositionAttribute.TURN,
+                PositionAttribute.KINGS,
+                PositionAttribute.EN_PASSANT,
+                PositionAttribute.HALFMOVE_CLOCK,
+            )
+        ),
+        changed_facts=(MaterialAnalyzer(FactPerspective.WHITE),),
+        preserved_facts=(MaterialAnalyzer(FactPerspective.BLACK),),
+    )
+
+    result = remove_piece_counterfactual(chess.Board(), chess.A1, constraints=constraints)
+
+    assert result.succeeded
+    assert result.validity is CounterfactualValidity.RULE_VALID
+    assert result.modified is not None
+    assert result.modified.rule_valid
+    assert not result.modified.history_complete
+    assert result.history.original_complete
+    assert not result.history.modified_complete
+    assert not result.history.shared_parent
+    assert not result.history.legal_from_shared_parent
+    assert not result.history.reachability_proven
+    attributes = {item.attribute: item for item in result.attributes}
+    assert len(attributes) == len(PositionAttribute)
+    assert attributes[PositionAttribute.MATERIAL].changed
+    assert attributes[PositionAttribute.CASTLING_RIGHTS].changed
+    assert not attributes[PositionAttribute.TURN].changed
+    assert {item.attribute for item in result.changed_attributes} == {
+        PositionAttribute.MATERIAL,
+        PositionAttribute.CASTLING_RIGHTS,
+    }
+    assert all(item.satisfied for item in (*result.changed_attributes, *result.preserved_attributes))
+    assert result.changed_facts[0].relation is ConstraintRelation.CHANGED
+    assert result.changed_facts[0].original.value == 39
+    assert result.changed_facts[0].modified.value == 34
+    assert result.preserved_facts[0].satisfied
+
+
+def test_relocation_preserves_material_but_loses_structural_history():
+    result = relocate_piece_counterfactual(
+        chess.Board(),
+        chess.B1,
+        chess.A3,
+        constraints=CounterfactualConstraints(
+            changed_attributes=frozenset((PositionAttribute.HISTORY,)),
+            preserved_attributes=frozenset(
+                (
+                    PositionAttribute.TURN,
+                    PositionAttribute.KINGS,
+                    PositionAttribute.MATERIAL,
+                    PositionAttribute.CASTLING_RIGHTS,
+                    PositionAttribute.EN_PASSANT,
+                    PositionAttribute.HALFMOVE_CLOCK,
+                )
+            ),
+            preserved_facts=(MaterialAnalyzer(FactPerspective.WHITE),),
+        ),
+    )
+
+    assert result.succeeded
+    assert result.modified is not None
+    modified = chess.Board(result.modified.fen)
+    assert modified.piece_at(chess.B1) is None
+    assert modified.piece_at(chess.A3) == chess.Piece(chess.KNIGHT, chess.WHITE)
+    assert all(item.satisfied for item in (*result.changed_attributes, *result.preserved_attributes))
+    assert result.preserved_facts[0].satisfied
+
+
+def test_structural_operators_return_structured_failures():
+    empty = remove_piece_counterfactual(chess.Board(), chess.E4)
+    king = remove_piece_counterfactual(chess.Board(), chess.E1)
+    occupied = relocate_piece_counterfactual(chess.Board(), chess.B1, chess.A2)
+    constraint = relocate_piece_counterfactual(
+        chess.Board(),
+        chess.B1,
+        chess.A3,
+        constraints=CounterfactualConstraints(
+            changed_attributes=frozenset((PositionAttribute.MATERIAL,)),
+        ),
+    )
+
+    assert empty.failures[0].reason is CounterfactualFailureReason.EMPTY_SOURCE_SQUARE
+    assert king.failures[0].reason is CounterfactualFailureReason.KING_EDIT_FORBIDDEN
+    assert occupied.failures[0].reason is CounterfactualFailureReason.OCCUPIED_TARGET_SQUARE
+    assert constraint.failures[0].reason is CounterfactualFailureReason.CONSTRAINT_VIOLATION
+    assert constraint.failures[0].attribute is PositionAttribute.MATERIAL
+    assert all(result.modified is None for result in (empty, king, occupied, constraint))
+
+
+def test_relocation_rejects_king_empty_source_and_invalid_result():
+    empty = relocate_piece_counterfactual(chess.Board(), chess.E4, chess.E5)
+    king = relocate_piece_counterfactual(chess.Board(), chess.E1, chess.E3)
+    exposes_opposite_king = chess.Board("4k3/4b3/8/8/8/8/4R3/4K3 w - - 0 1")
+    invalid = relocate_piece_counterfactual(exposes_opposite_king, chess.E7, chess.A7)
+
+    assert empty.failures[0].reason is CounterfactualFailureReason.EMPTY_SOURCE_SQUARE
+    assert king.failures[0].reason is CounterfactualFailureReason.KING_EDIT_FORBIDDEN
+    assert invalid.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
+    assert "status 1024" in invalid.failures[0].message
+
+
+def test_structural_edit_clears_invalid_en_passant_and_reports_the_change():
+    board = chess.Board()
+    board.push_uci("e2e4")
+
+    result = relocate_piece_counterfactual(
+        board,
+        chess.E4,
+        chess.E5,
+        constraints=CounterfactualConstraints(
+            changed_attributes=frozenset((PositionAttribute.EN_PASSANT, PositionAttribute.HISTORY)),
+        ),
+    )
+
+    assert result.succeeded
+    assert result.modified is not None
+    assert chess.Board(result.modified.fen).ep_square is None
+    ep = next(item for item in result.attributes if item.attribute is PositionAttribute.EN_PASSANT)
+    assert ep.original == chess.E3
+    assert ep.modified is None
+    assert ep.changed
+
+
+def test_truncated_sibling_declares_only_shared_parent_legality():
+    parent = chess.Board("rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1")
+
+    result = sibling_counterfactual(
+        parent,
+        chess.Move.from_uci("e7e5"),
+        chess.Move.from_uci("d7d5"),
+    )
+
+    assert result.succeeded
+    assert result.validity is CounterfactualValidity.SIBLING_LEGAL_MOVE
+    assert result.history.shared_parent
+    assert result.history.legal_from_shared_parent
+    assert not result.history.original_complete
+    assert not result.history.modified_complete
+    assert not result.history.reachability_proven
+
+
+def test_invalid_source_positions_and_malformed_configuration_are_rejected():
+    invalid = chess.Board("8/8/8/8/8/8/4P3/4K3 w - - 0 1")
+
+    sibling = sibling_counterfactual(invalid, chess.Move.from_uci("e2e3"))
+    removal = remove_piece_counterfactual(invalid, chess.E2)
+    relocation = relocate_piece_counterfactual(invalid, chess.E2, chess.E3)
+
+    assert sibling.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
+    assert removal.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
+    assert relocation.failures[0].reason is CounterfactualFailureReason.INVALID_POSITION
+    with pytest.raises(TypeError, match="python-chess Board"):
+        remove_piece_counterfactual("not a board", chess.E2)
+    with pytest.raises(ValueError, match="Invalid chess square"):
+        RemovePieceOperator(99)
+    with pytest.raises(ValueError, match="must differ"):
+        RelocatePieceOperator(chess.A1, chess.A1)
+    with pytest.raises(ValueError, match="both changed and preserved"):
+        CounterfactualConstraints(
+            changed_attributes=frozenset((PositionAttribute.TURN,)),
+            preserved_attributes=frozenset((PositionAttribute.TURN,)),
+        )
+    with pytest.raises(ValueError, match="PositionAttribute"):
+        CounterfactualConstraints(changed_attributes=frozenset(("turn",)))
+    with pytest.raises(TypeError, match="FactAnalyzer"):
+        CounterfactualConstraints(changed_facts=("material",))
+
+
+def test_sibling_failures_distinguish_illegal_moves_and_no_alternative():
+    illegal_factual = sibling_counterfactual(chess.Board(), chess.Move.from_uci("e2e5"))
+    illegal_alternative = sibling_counterfactual(
+        chess.Board(), chess.Move.from_uci("e2e4"), chess.Move.from_uci("e2e4")
+    )
+    forced = chess.Board("8/8/8/8/8/6k1/5r2/7K w - - 0 1")
+    only_move = next(iter(forced.legal_moves))
+    no_alternative = sibling_counterfactual(forced, only_move)
+
+    assert illegal_factual.failures[0].reason is CounterfactualFailureReason.ILLEGAL_FACTUAL_MOVE
+    assert illegal_alternative.failures[0].reason is CounterfactualFailureReason.ILLEGAL_ALTERNATIVE_MOVE
+    assert no_alternative.failures[0].reason is CounterfactualFailureReason.NO_ALTERNATIVE
+
+
+def test_property_every_explicit_starting_sibling_is_rule_valid_and_uses_same_parent():
+    parent = chess.Board()
+    factual = chess.Move.from_uci("e2e4")
+
+    for alternative in sorted((move for move in parent.legal_moves if move != factual), key=lambda move: move.uci()):
+        result = sibling_counterfactual(parent, factual, alternative)
+
+        assert result.succeeded, alternative.uci()
+        assert result.modified is not None
+        assert result.modified.rule_valid
+        assert result.history.shared_parent
+        assert result.history.legal_from_shared_parent
+        assert isinstance(result.operator, SiblingMoveOperator)
+        assert result.operator.alternative_move == alternative
+
+
+def test_property_removing_any_starting_non_king_piece_never_returns_a_malformed_state():
+    board = chess.Board()
+
+    for square, piece in board.piece_map().items():
+        if piece.piece_type == chess.KING:
+            continue
+        result = remove_piece_counterfactual(board, square)
+
+        assert result.succeeded, chess.square_name(square)
+        assert result.validity is CounterfactualValidity.RULE_VALID
+        assert result.modified is not None
+        assert result.modified.rule_valid
+        assert not result.history.reachability_proven


### PR DESCRIPTION
## Summary

- add typed sibling, piece-removal, and piece-relocation counterfactual operators
- declare rule-valid, sibling-legal, and history-consistent validity tiers with explicit history guarantees
- verify changed and preserved metadata/fact constraints using evidence from the exact fact analyzers
- return structured failures and normalize structural castling/en-passant metadata without claiming reachability
- document the API and add handwritten plus property-style tests

## Why

Arbitrary board edits were not safe to describe as reachable chess positions. This introduces an auditable, framework-independent boundary that distinguishes legal sibling histories from merely rule-valid structural states.

## Validation

- `just checks`
- `just tests` — 218 passed, 12 deselected, 88.20% total branch coverage
- focused counterfactual branch coverage — 99%
- `just docs` — succeeded with the existing warning set

Closes #133