### PR TITLE
Add evaluator and search behavior comparison primitives

### DIFF
--- a/docs/source/behavior.rst
+++ b/docs/source/behavior.rst
@@ -1,0 +1,67 @@
+Observable behaviour comparisons
+================================
+
+``lczerolens.behavior`` compares what an evaluator or search source actually
+exposed. It is an evidence boundary: it does not implement attribution, hooks,
+probes, sparse autoencoders, or natural-language explanation algorithms.
+
+Evaluator behaviour
+-------------------
+
+:func:`~lczerolens.behavior.evaluator_behavior` accepts one
+:class:`~lczerolens.board.LczeroBoard` and the canonical evaluator output.
+``policy`` is required and interpreted as 1858 raw logits. Illegal actions are
+removed before a legal-action softmax. Candidate ranks use competition ranking;
+exact maximum-logit ties are retained and the selected representative uses UCI
+lexicographic order. Value, WDL, and MLH are optional and remain absent instead
+of being derived from another head. Values and WDL state their perspective.
+
+All definitions are available through
+:data:`lczerolens.behavior.METRIC_DEFINITIONS`. Each definition fixes
+perspective, normalization, single-position or snapshot aggregation, ties,
+missing/illegal-action handling, and any required search capability.
+
+Search behaviour
+----------------
+
+:func:`~lczerolens.behavior.compare_evaluator_to_search` requires root action
+statistics and returns evaluator probability/rank alongside P, N, visit share,
+Q, PV, visit amplification, and final selection for each exposed root action.
+Policy-to-search divergence is total variation between visit shares and
+evaluator probabilities conditional on the exposed action set. The original
+evaluator probability mass covered by that set is reported separately, so a
+partial public engine record cannot be mistaken for a complete legal-action
+comparison.
+
+Budget-labelled traces additionally expose candidate-rank and Q evolution,
+selected-move changes, the first budget at which a move received a visit, and
+adjacent-PV prefix stability. Unavailable source fields remain ``None``.
+
+Event metrics are deliberately separate. Calling
+:func:`~lczerolens.behavior.compare_search_events` on a root-only trace raises
+:class:`~lczerolens.search_trace.SearchCapabilityError`. Path-depth and
+expansion summaries require ``full_events``; independent root transition
+validation additionally requires ``replayable``. Official lc0 public root
+output and :class:`~lczerolens.reference_search.ReferenceMCTS` may therefore be
+compared through the same root vocabulary without claiming that their search
+algorithms, strengths, or capabilities are equivalent.
+
+Counterfactual behaviour and controls
+-------------------------------------
+
+:func:`~lczerolens.behavior.compare_counterfactual_behavior` takes two
+standardized evaluator records and a non-empty set of target moves. Every
+target receives its own probability, rank, and selection effect. All other
+legal actions form a separate collateral record, including union-set total
+variation when the legal move sets differ. ``matched``, ``shuffled``, and
+``wrong_target`` are first-class :class:`~lczerolens.behavior.ControlKind`
+values rather than labels hidden in prose.
+
+A successful :class:`~lczerolens.counterfactuals.CounterfactualResult` and
+supplied :class:`~lczerolens.move_evidence.VariationEvidence` can be retained
+with the comparison. :func:`~lczerolens.behavior.compare_search_decision`
+combines the evaluator's initial candidate, the source-selected search
+candidate, their root statistics, source capability, and any supplied
+variation evidence. It provides the structured checkpoint-D evidence needed
+to ask why search preferred one candidate without generating or asserting a
+heuristic chess explanation.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,6 +12,7 @@ lczerolens
     scope
     facts
     search
+    behavior
     features
     tutorials
     api/index

--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -3,6 +3,19 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .board import LczeroBoard
+from .behavior import (
+    BehaviorMetric,
+    ControlKind,
+    CounterfactualBehaviorComparison,
+    DecisionComparison,
+    EvaluatorBehavior,
+    SearchBehaviorComparison,
+    compare_counterfactual_behavior,
+    compare_evaluator_to_search,
+    compare_search_decision,
+    compare_search_events,
+    evaluator_behavior,
+)
 from .counterfactuals import (
     CounterfactualConstraints,
     CounterfactualResult,
@@ -26,11 +39,16 @@ except PackageNotFoundError:
 __all__ = [
     "LczeroBoard",
     "LczeroModel",
+    "BehaviorMetric",
+    "ControlKind",
     "CounterfactualConstraints",
+    "CounterfactualBehaviorComparison",
     "CounterfactualResult",
     "CounterfactualValidity",
+    "DecisionComparison",
     "Evidence",
     "EvidenceSet",
+    "EvaluatorBehavior",
     "FactAnalyzer",
     "Lc0ProcessAdapter",
     "Lc0RootSnapshotParser",
@@ -38,9 +56,15 @@ __all__ = [
     "MoveDelta",
     "PositionAttribute",
     "ReferenceMCTS",
+    "SearchBehaviorComparison",
     "VariationEvidence",
     "analyze_move_delta",
     "analyze_variation",
+    "compare_counterfactual_behavior",
+    "compare_evaluator_to_search",
+    "compare_search_decision",
+    "compare_search_events",
+    "evaluator_behavior",
     "relocate_piece_counterfactual",
     "remove_piece_counterfactual",
     "replay_root_events",

--- a/src/lczerolens/behavior.py
+++ b/src/lczerolens/behavior.py
@@ -348,22 +348,30 @@ def compare_evaluator_to_search(evaluator: EvaluatorBehavior, trace: SearchTrace
         for action in final_actions
     )
     divergence = 0.5 * sum(abs(conditional[move] - shares[move]) for move in conditional) if shares else None
-    snapshots = tuple(
-        _snapshot_behavior(
-            snapshot.sequence,
-            snapshot.budget,
-            snapshot.selection.move if snapshot.selection else None,
-            snapshot.actions or (),
+    if trace.supports(SearchCapability.ROOT_SNAPSHOTS):
+        snapshots = tuple(
+            _snapshot_behavior(
+                snapshot.sequence,
+                snapshot.budget,
+                snapshot.selection.move if snapshot.selection else None,
+                snapshot.actions or (),
+            )
+            for snapshot in trace.snapshots
         )
-        for snapshot in trace.snapshots
-    )
-    changes = tuple(
-        (current.sequence, previous.selected_move, current.selected_move)
-        for previous, current in zip(snapshots, snapshots[1:])
-        if previous.selected_move is not None
-        and current.selected_move is not None
-        and previous.selected_move != current.selected_move
-    )
+        changes = tuple(
+            (current.sequence, previous.selected_move, current.selected_move)
+            for previous, current in zip(snapshots, snapshots[1:])
+            if previous.selected_move is not None
+            and current.selected_move is not None
+            and previous.selected_move != current.selected_move
+        )
+        discovery_budgets = _discovery_budgets(trace)
+        pv_stability = _pv_stability(trace)
+    else:
+        snapshots = ()
+        changes = ()
+        discovery_budgets = ()
+        pv_stability = ()
     return SearchBehaviorComparison(
         source=trace.provenance.source,
         capability=trace.capability,
@@ -375,8 +383,8 @@ def compare_evaluator_to_search(evaluator: EvaluatorBehavior, trace: SearchTrace
         actions=comparisons,
         snapshots=snapshots,
         selected_move_changes=changes,
-        discovery_budgets=_discovery_budgets(trace),
-        pv_stability=_pv_stability(trace),
+        discovery_budgets=discovery_budgets,
+        pv_stability=pv_stability,
     )
 
 
@@ -400,9 +408,9 @@ def compare_search_events(trace: SearchTrace, *, validate_replay: bool = False) 
     replay_validated = None
     if validate_replay:
         trace.require(SearchCapability.REPLAYABLE)
-        replay_validated = replay_root_events(events) == tuple(
-            action.statistics for action in trace.snapshots[-1].actions or ()
-        )
+        replayed = {edge.move: edge for edge in replay_root_events(events)}
+        final = {action.statistics.move: action.statistics for action in trace.snapshots[-1].actions or ()}
+        replay_validated = replayed == final
     return SearchEventBehavior(
         event_count=len(events),
         maximum_path_depth=max(depths, default=0),
@@ -512,6 +520,8 @@ def compare_counterfactual_behavior(
     for move, variation in evidence:
         if not variation.moves or variation.moves[0].uci() != move:
             raise ValueError("Variation evidence must begin with the move named by its key.")
+        if variation.initial.fen not in (original.fen, modified.fen):
+            raise ValueError("Variation evidence must begin at the original or modified evaluator FEN.")
     return CounterfactualBehaviorComparison(
         control_kind,
         original,
@@ -650,8 +660,6 @@ def _snapshot_behavior(
 
 
 def _discovery_budgets(trace: SearchTrace) -> tuple[tuple[str, SearchBudget | None], ...]:
-    if not trace.supports(SearchCapability.ROOT_SNAPSHOTS):
-        return ()
     moves = sorted({action.statistics.move for snapshot in trace.snapshots for action in snapshot.actions or ()})
     result = []
     for move in moves:
@@ -669,8 +677,6 @@ def _discovery_budgets(trace: SearchTrace) -> tuple[tuple[str, SearchBudget | No
 
 
 def _pv_stability(trace: SearchTrace) -> tuple[tuple[str, float | None], ...]:
-    if not trace.supports(SearchCapability.ROOT_SNAPSHOTS):
-        return ()
     moves = sorted({action.statistics.move for snapshot in trace.snapshots for action in snapshot.actions or ()})
     result = []
     for move in moves:

--- a/src/lczerolens/behavior.py
+++ b/src/lczerolens/behavior.py
@@ -1,0 +1,741 @@
+"""Typed comparisons for observable evaluator and search behaviour.
+
+This module compares records already produced at the lc0 interoperability and
+chess-evidence boundary.  It deliberately does not implement attribution,
+probing, hooks, sparse autoencoders, or natural-language explanation methods.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+import chess
+import torch
+from tensordict import TensorDict
+
+from .board import LczeroBoard
+from .counterfactuals import CounterfactualResult
+from .move_evidence import VariationEvidence
+from .reference_search import replay_root_events
+from .search_trace import (
+    PositionEvaluation,
+    PrincipalVariation,
+    RootAction,
+    SearchBudget,
+    SearchCapability,
+    SearchTrace,
+    ValuePerspective,
+    Wdl,
+)
+
+
+class BehaviorMetric(str, Enum):
+    """Stable names for the observable metrics defined by this module."""
+
+    LEGAL_POLICY_LOGIT = "legal_policy_logit"
+    LEGAL_POLICY_PROBABILITY = "legal_policy_probability"
+    CANDIDATE_RANK = "candidate_rank"
+    SELECTED_ACTION = "selected_action"
+    VALUE = "value"
+    WDL = "wdl"
+    MLH = "mlh"
+    POLICY_SEARCH_DIVERGENCE = "policy_search_divergence"
+    VISIT_AMPLIFICATION = "visit_amplification"
+    CANDIDATE_RANK_EVOLUTION = "candidate_rank_evolution"
+    Q_EVOLUTION = "q_evolution"
+    SELECTED_MOVE_CHANGES = "selected_move_changes"
+    DISCOVERY_BUDGET = "discovery_budget"
+    PV_STABILITY = "pv_stability"
+    EVENT_PATH_DEPTH = "event_path_depth"
+    REPLAY_VALIDATION = "replay_validation"
+
+
+@dataclass(frozen=True)
+class MetricDefinition:
+    """Complete interpretation contract for one metric."""
+
+    perspective: str
+    normalization: str
+    aggregation: str
+    ties: str
+    missing_or_illegal: str
+    required_capability: SearchCapability | None = None
+
+
+_ROOT_DEFINITION = MetricDefinition(
+    perspective="each root edge's explicitly stated perspective",
+    normalization="visit shares are normalized over exposed root actions with total N > 0",
+    aggregation="one budget-labelled root snapshot",
+    ties="competition rank; source selection and its declared tie rule are retained",
+    missing_or_illegal="unexposed statistics remain None; illegal root actions are rejected by SearchTrace",
+    required_capability=SearchCapability.ROOT_ACTION_STATS,
+)
+
+
+METRIC_DEFINITIONS: Mapping[BehaviorMetric, MetricDefinition] = {
+    BehaviorMetric.LEGAL_POLICY_LOGIT: MetricDefinition(
+        "side to move at the evaluated position",
+        "none; raw logits are retained after legal masking",
+        "one legal action at one position",
+        "exact equality is retained",
+        "illegal actions are excluded; policy is required",
+    ),
+    BehaviorMetric.LEGAL_POLICY_PROBABILITY: MetricDefinition(
+        "side to move at the evaluated position",
+        "softmax over exactly the legal policy logits",
+        "one legal action at one position",
+        "exact equality is retained",
+        "illegal actions are excluded; policy is required",
+    ),
+    BehaviorMetric.CANDIDATE_RANK: MetricDefinition(
+        "side to move at the evaluated position",
+        "competition rank over legal logits",
+        "one legal action at one position",
+        "equal logits receive equal rank and skip subsequent ranks",
+        "illegal actions have no rank; policy is required",
+    ),
+    BehaviorMetric.SELECTED_ACTION: MetricDefinition(
+        "side to move at the evaluated position",
+        "maximum legal logit",
+        "one position",
+        "all exact maxima are retained; UCI lexicographic representative",
+        "illegal actions cannot be selected; policy is required",
+    ),
+    BehaviorMetric.VALUE: MetricDefinition(
+        "the EvaluatorBehavior perspective",
+        "none; scalar value must be in [-1, 1]",
+        "one position",
+        "not applicable",
+        "missing value head remains None",
+    ),
+    BehaviorMetric.WDL: MetricDefinition(
+        "the EvaluatorBehavior perspective",
+        "already-normalized (win, draw, loss) probabilities summing to one",
+        "one position",
+        "not applicable",
+        "missing WDL head remains None",
+    ),
+    BehaviorMetric.MLH: MetricDefinition(
+        "source-reported scalar; no player sign conversion",
+        "none",
+        "one position",
+        "not applicable",
+        "missing MLH head remains None",
+    ),
+    BehaviorMetric.POLICY_SEARCH_DIVERGENCE: _ROOT_DEFINITION,
+    BehaviorMetric.VISIT_AMPLIFICATION: MetricDefinition(
+        perspective="policy and visits are unsigned root-action weights",
+        normalization="normalized visit share divided by evaluator probability conditional on exposed actions",
+        aggregation="one root action at one budget-labelled snapshot",
+        ties="not applicable",
+        missing_or_illegal="None when visits are unavailable, total visits are zero, or conditional probability is zero",
+        required_capability=SearchCapability.ROOT_ACTION_STATS,
+    ),
+    BehaviorMetric.CANDIDATE_RANK_EVOLUTION: MetricDefinition(
+        **{**_ROOT_DEFINITION.__dict__, "required_capability": SearchCapability.ROOT_SNAPSHOTS}
+    ),
+    BehaviorMetric.Q_EVOLUTION: MetricDefinition(
+        **{**_ROOT_DEFINITION.__dict__, "required_capability": SearchCapability.ROOT_SNAPSHOTS}
+    ),
+    BehaviorMetric.SELECTED_MOVE_CHANGES: MetricDefinition(
+        **{**_ROOT_DEFINITION.__dict__, "required_capability": SearchCapability.ROOT_SNAPSHOTS}
+    ),
+    BehaviorMetric.DISCOVERY_BUDGET: MetricDefinition(
+        **{**_ROOT_DEFINITION.__dict__, "required_capability": SearchCapability.ROOT_SNAPSHOTS}
+    ),
+    BehaviorMetric.PV_STABILITY: MetricDefinition(
+        perspective="root player; PV moves retain source order",
+        normalization="common-prefix length divided by the longer adjacent PV length",
+        aggregation="mean over adjacent available PV pairs for each root action",
+        ties="not applicable",
+        missing_or_illegal="actions with fewer than two exposed PVs receive None",
+        required_capability=SearchCapability.ROOT_SNAPSHOTS,
+    ),
+    BehaviorMetric.EVENT_PATH_DEPTH: MetricDefinition(
+        perspective="rooted path depth; no value conversion",
+        normalization="none",
+        aggregation="maximum and mean across emitted events",
+        ties="not applicable",
+        missing_or_illegal="refused unless full events are advertised",
+        required_capability=SearchCapability.FULL_EVENTS,
+    ),
+    BehaviorMetric.REPLAY_VALIDATION: MetricDefinition(
+        perspective="root player statistics",
+        normalization="none",
+        aggregation="all emitted event transitions",
+        ties="not applicable",
+        missing_or_illegal="refused unless replayable events are advertised",
+        required_capability=SearchCapability.REPLAYABLE,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class EvaluatorAction:
+    """One legal evaluator action after legal masking and normalization."""
+
+    move: str
+    logit: float
+    probability: float
+    rank: int
+
+
+@dataclass(frozen=True)
+class EvaluatorBehavior:
+    """Standardized single-position evaluator behaviour."""
+
+    fen: str
+    perspective: ValuePerspective
+    actions: tuple[EvaluatorAction, ...]
+    selected_move: str
+    selection_ties: tuple[str, ...]
+    tie_break: str
+    evaluation: PositionEvaluation | None = None
+    mlh: float | None = None
+
+    def action(self, move: str) -> EvaluatorAction | None:
+        """Return a legal action record, or ``None`` for a missing/illegal move."""
+        return next((action for action in self.actions if action.move == move), None)
+
+
+def evaluator_behavior(
+    board: LczeroBoard,
+    output: TensorDict | Mapping[str, torch.Tensor],
+    *,
+    perspective: ValuePerspective = ValuePerspective.SIDE_TO_MOVE,
+) -> EvaluatorBehavior:
+    """Normalize one evaluator output over legal moves with explicit ties.
+
+    ``policy`` is interpreted as raw logits. ``wdl`` is interpreted as the
+    already-normalized lc0 ``(win, draw, loss)`` head. Optional scalar heads are
+    retained only when present; no head is derived from another head.
+    """
+    if not isinstance(board, LczeroBoard):
+        raise TypeError("Evaluator behaviour requires an LczeroBoard.")
+    if not isinstance(perspective, ValuePerspective):
+        raise ValueError("perspective must be a ValuePerspective.")
+    policy = _single_tensor(output, "policy", required=True)
+    if policy.numel() != 1858 or not torch.isfinite(policy).all():
+        raise ValueError("policy must contain 1858 finite raw logits for one position.")
+    legal_moves = tuple(sorted(board.legal_moves, key=lambda move: move.uci()))
+    if not legal_moves:
+        raise ValueError("Evaluator behaviour requires a non-terminal position with legal moves.")
+    logits = torch.tensor(
+        [float(policy[board.encode_move(move, board.turn)].item()) for move in legal_moves], dtype=torch.float64
+    )
+    probabilities = torch.softmax(logits, dim=0)
+    values = logits.tolist()
+    ranks = _competition_ranks(values)
+    maximum = max(values)
+    tied = tuple(move.uci() for move, value in zip(legal_moves, values) if value == maximum)
+    actions = tuple(
+        EvaluatorAction(move.uci(), logit, float(probability), rank)
+        for move, logit, probability, rank in zip(legal_moves, values, probabilities.tolist(), ranks)
+    )
+    value_tensor = _single_tensor(output, "value")
+    wdl_tensor = _single_tensor(output, "wdl")
+    mlh_tensor = _single_tensor(output, "mlh")
+    value = _optional_scalar(value_tensor, "value", minimum=-1.0, maximum=1.0)
+    mlh = _optional_scalar(mlh_tensor, "mlh")
+    wdl = None
+    if wdl_tensor is not None:
+        if wdl_tensor.numel() != 3:
+            raise ValueError("wdl must contain exactly (win, draw, loss) for one position.")
+        entries = tuple(float(item) for item in wdl_tensor.reshape(-1).tolist())
+        wdl = Wdl(*entries, perspective)
+    evaluation = (
+        PositionEvaluation(perspective, value=value, wdl=wdl) if value is not None or wdl is not None else None
+    )
+    return EvaluatorBehavior(
+        board.fen(),
+        perspective,
+        actions,
+        tied[0],
+        tied,
+        "UCI lexicographic among exact maximum logits",
+        evaluation,
+        mlh,
+    )
+
+
+@dataclass(frozen=True)
+class SearchActionComparison:
+    """Evaluator preference and final root-search statistics for one move."""
+
+    move: str
+    evaluator_probability: float | None
+    evaluator_rank: int | None
+    search_prior: float | None
+    visits: int | None
+    visit_share: float | None
+    visit_probability_delta: float | None
+    visit_amplification: float | None
+    search_rank: int | None
+    search_perspective: ValuePerspective
+    mean_value: float | None
+    principal_variation: PrincipalVariation | None
+
+
+@dataclass(frozen=True)
+class SearchSnapshotBehavior:
+    """Candidate evolution at one source snapshot."""
+
+    sequence: int
+    budget: SearchBudget | None
+    selected_move: str | None
+    ranks: tuple[tuple[str, int | None], ...]
+    q_values: tuple[tuple[str, float | None], ...]
+
+
+@dataclass(frozen=True)
+class SearchBehaviorComparison:
+    """Root-only evaluator-to-search comparison."""
+
+    source: str
+    capability: SearchCapability
+    evaluator_selected_move: str
+    search_selected_move: str | None
+    selection_changed: bool | None
+    evaluator_probability_coverage: float
+    policy_search_total_variation: float | None
+    actions: tuple[SearchActionComparison, ...]
+    snapshots: tuple[SearchSnapshotBehavior, ...]
+    selected_move_changes: tuple[tuple[int, str, str], ...]
+    discovery_budgets: tuple[tuple[str, SearchBudget | None], ...]
+    pv_stability: tuple[tuple[str, float | None], ...]
+
+    def action(self, move: str) -> SearchActionComparison | None:
+        """Return the comparison for an exposed root action."""
+        return next((action for action in self.actions if action.move == move), None)
+
+
+def compare_evaluator_to_search(evaluator: EvaluatorBehavior, trace: SearchTrace) -> SearchBehaviorComparison:
+    """Compare legal evaluator preference with capability-safe root statistics.
+
+    Divergence is total variation between evaluator probabilities and visit
+    shares, conditional on the root actions exposed by the search source. The
+    separately reported evaluator probability coverage prevents a partial
+    source from being mistaken for a complete legal-action comparison.
+    """
+    trace.require(SearchCapability.ROOT_ACTION_STATS)
+    if evaluator.fen != trace.root_fen:
+        raise ValueError("Evaluator behaviour and search trace must describe the same root FEN.")
+    if evaluator.perspective not in (ValuePerspective.SIDE_TO_MOVE, ValuePerspective.ROOT_PLAYER):
+        raise ValueError("Evaluator policy comparison must use side-to-move or root-player perspective.")
+    final = trace.snapshots[-1]
+    final_actions = final.actions or ()
+    evaluator_by_move = {action.move: action for action in evaluator.actions}
+    coverage = sum(evaluator_by_move[action.statistics.move].probability for action in final_actions)
+    exposed_logits = torch.tensor(
+        [evaluator_by_move[action.statistics.move].logit for action in final_actions], dtype=torch.float64
+    )
+    conditional = {
+        action.statistics.move: probability
+        for action, probability in zip(final_actions, torch.softmax(exposed_logits, dim=0).tolist())
+    }
+    visit_total = sum(action.statistics.visits or 0 for action in final_actions)
+    visits_available = bool(final_actions) and all(action.statistics.visits is not None for action in final_actions)
+    shares = (
+        {action.statistics.move: (action.statistics.visits or 0) / visit_total for action in final_actions}
+        if visits_available and visit_total > 0
+        else {}
+    )
+    search_ranks = _optional_action_ranks(final_actions)
+    comparisons = tuple(
+        _search_action_comparison(action, evaluator_by_move[action.statistics.move], conditional, shares, search_ranks)
+        for action in final_actions
+    )
+    divergence = 0.5 * sum(abs(conditional[move] - shares[move]) for move in conditional) if shares else None
+    snapshots = tuple(
+        _snapshot_behavior(
+            snapshot.sequence,
+            snapshot.budget,
+            snapshot.selection.move if snapshot.selection else None,
+            snapshot.actions or (),
+        )
+        for snapshot in trace.snapshots
+    )
+    changes = tuple(
+        (current.sequence, previous.selected_move, current.selected_move)
+        for previous, current in zip(snapshots, snapshots[1:])
+        if previous.selected_move is not None
+        and current.selected_move is not None
+        and previous.selected_move != current.selected_move
+    )
+    return SearchBehaviorComparison(
+        source=trace.provenance.source,
+        capability=trace.capability,
+        evaluator_selected_move=evaluator.selected_move,
+        search_selected_move=final.selection.move if final.selection else None,
+        selection_changed=(final.selection.move != evaluator.selected_move) if final.selection else None,
+        evaluator_probability_coverage=coverage,
+        policy_search_total_variation=divergence,
+        actions=comparisons,
+        snapshots=snapshots,
+        selected_move_changes=changes,
+        discovery_budgets=_discovery_budgets(trace),
+        pv_stability=_pv_stability(trace),
+    )
+
+
+@dataclass(frozen=True)
+class SearchEventBehavior:
+    """Metrics which are unavailable from root snapshots alone."""
+
+    event_count: int
+    maximum_path_depth: int
+    mean_path_depth: float
+    expanded_node_count: int
+    terminal_leaf_count: int
+    replay_validated: bool | None
+
+
+def compare_search_events(trace: SearchTrace, *, validate_replay: bool = False) -> SearchEventBehavior:
+    """Summarize emitted events, refusing unsupported full-event claims."""
+    trace.require(SearchCapability.FULL_EVENTS)
+    events = trace.events or ()
+    depths = [len(event.path) for event in events]
+    replay_validated = None
+    if validate_replay:
+        trace.require(SearchCapability.REPLAYABLE)
+        replay_validated = replay_root_events(events) == tuple(
+            action.statistics for action in trace.snapshots[-1].actions or ()
+        )
+    return SearchEventBehavior(
+        event_count=len(events),
+        maximum_path_depth=max(depths, default=0),
+        mean_path_depth=sum(depths) / len(depths) if depths else 0.0,
+        expanded_node_count=sum(event.expansion is not None for event in events),
+        terminal_leaf_count=sum(event.leaf.terminal for event in events),
+        replay_validated=replay_validated,
+    )
+
+
+class ControlKind(str, Enum):
+    """First-class counterfactual control relationship."""
+
+    MATCHED = "matched"
+    SHUFFLED = "shuffled"
+    WRONG_TARGET = "wrong_target"
+
+
+@dataclass(frozen=True)
+class TargetEffect:
+    """Behavioural effect for one declared target move."""
+
+    move: str
+    original_probability: float | None
+    modified_probability: float | None
+    probability_delta: float | None
+    original_rank: int | None
+    modified_rank: int | None
+    rank_delta: int | None
+    originally_selected: bool
+    modified_selected: bool
+
+
+@dataclass(frozen=True)
+class CollateralEffect:
+    """Aggregate change outside the explicitly declared targets."""
+
+    moves: tuple[str, ...]
+    probability_l1: float
+    probability_total_variation: float
+    selected_move_changed: bool
+
+
+@dataclass(frozen=True)
+class CounterfactualBehaviorComparison:
+    """Target-separated behaviour for a counterfactual or control pair."""
+
+    control_kind: ControlKind
+    original: EvaluatorBehavior
+    modified: EvaluatorBehavior
+    targets: tuple[TargetEffect, ...]
+    collateral: CollateralEffect
+    counterfactual: CounterfactualResult | None = None
+    variation_evidence: tuple[tuple[str, VariationEvidence], ...] = ()
+
+
+def compare_counterfactual_behavior(
+    original: EvaluatorBehavior,
+    modified: EvaluatorBehavior,
+    target_moves: tuple[str, ...],
+    *,
+    control_kind: ControlKind = ControlKind.MATCHED,
+    counterfactual: CounterfactualResult | None = None,
+    variation_evidence: Mapping[str, VariationEvidence] | None = None,
+) -> CounterfactualBehaviorComparison:
+    """Report declared target effects separately from all collateral effects."""
+    if not isinstance(control_kind, ControlKind):
+        raise ValueError("control_kind must be a ControlKind.")
+    if (
+        original.perspective is not modified.perspective
+        or chess.Board(original.fen).turn != chess.Board(modified.fen).turn
+    ):
+        raise ValueError("Counterfactual behaviours must use the same perspective and absolute side to move.")
+    if not target_moves or len(target_moves) != len(set(target_moves)):
+        raise ValueError("target_moves must be a non-empty tuple of unique UCI moves.")
+    for move in target_moves:
+        try:
+            chess.Move.from_uci(move)
+        except ValueError as error:
+            raise ValueError(f"Invalid target UCI move: {move!r}.") from error
+    if counterfactual is not None and not counterfactual.succeeded:
+        raise ValueError("A linked counterfactual result must have succeeded.")
+    if counterfactual is not None and (
+        counterfactual.original.fen != original.fen
+        or counterfactual.modified is None
+        or counterfactual.modified.fen != modified.fen
+    ):
+        raise ValueError("Linked counterfactual positions must match the evaluator behaviours.")
+    original_by_move = {action.move: action for action in original.actions}
+    modified_by_move = {action.move: action for action in modified.actions}
+    targets = tuple(
+        _target_effect(move, original, modified, original_by_move.get(move), modified_by_move.get(move))
+        for move in target_moves
+    )
+    collateral_moves = tuple(sorted((original_by_move.keys() | modified_by_move.keys()) - set(target_moves)))
+    l1 = sum(
+        abs(
+            (modified_by_move[move].probability if move in modified_by_move else 0.0)
+            - (original_by_move[move].probability if move in original_by_move else 0.0)
+        )
+        for move in collateral_moves
+    )
+    evidence = tuple(sorted((variation_evidence or {}).items()))
+    unknown_evidence = {move for move, _ in evidence} - (set(target_moves) | set(collateral_moves))
+    if unknown_evidence:
+        raise ValueError("Variation evidence keys must name a target or collateral move.")
+    for move, variation in evidence:
+        if not variation.moves or variation.moves[0].uci() != move:
+            raise ValueError("Variation evidence must begin with the move named by its key.")
+    return CounterfactualBehaviorComparison(
+        control_kind,
+        original,
+        modified,
+        targets,
+        CollateralEffect(collateral_moves, l1, 0.5 * l1, original.selected_move != modified.selected_move),
+        counterfactual,
+        evidence,
+    )
+
+
+@dataclass(frozen=True)
+class DecisionComparison:
+    """Structured checkpoint-D answer without generated explanatory prose."""
+
+    evaluator_candidate: str
+    search_candidate: str
+    evaluator_candidate_comparison: SearchActionComparison
+    search_candidate_comparison: SearchActionComparison
+    evaluator_variation: VariationEvidence | None
+    search_variation: VariationEvidence | None
+    search_source: str
+    search_capability: SearchCapability
+
+
+def compare_search_decision(
+    evaluator: EvaluatorBehavior,
+    trace: SearchTrace,
+    *,
+    variation_evidence: Mapping[str, VariationEvidence] | None = None,
+) -> DecisionComparison:
+    """Link a search-over-evaluator preference change to supplied chess evidence."""
+    comparison = compare_evaluator_to_search(evaluator, trace)
+    if comparison.search_selected_move is None:
+        raise ValueError("Decision comparison requires an exposed search selection.")
+    evaluator_action = comparison.action(evaluator.selected_move)
+    search_action = comparison.action(comparison.search_selected_move)
+    if evaluator_action is None or search_action is None:
+        raise ValueError("Both evaluator and search candidates must have exposed root action statistics.")
+    evidence = variation_evidence or {}
+    for move, variation in evidence.items():
+        if variation.initial.fen != evaluator.fen or not variation.moves or variation.moves[0].uci() != move:
+            raise ValueError("Decision variation evidence must start at the root and begin with its keyed move.")
+    return DecisionComparison(
+        evaluator.selected_move,
+        comparison.search_selected_move,
+        evaluator_action,
+        search_action,
+        evidence.get(evaluator.selected_move),
+        evidence.get(comparison.search_selected_move),
+        trace.provenance.source,
+        trace.capability,
+    )
+
+
+def _single_tensor(
+    output: TensorDict | Mapping[str, torch.Tensor], key: str, *, required: bool = False
+) -> torch.Tensor | None:
+    value = output.get(key)
+    if value is None:
+        if required:
+            raise ValueError(f"Evaluator output is missing required {key!r} head.")
+        return None
+    if not isinstance(value, torch.Tensor):
+        raise ValueError(f"Evaluator head {key!r} must be a tensor.")
+    if value.ndim > 1 and value.shape[0] == 1:
+        value = value[0]
+    return value.reshape(-1)
+
+
+def _optional_scalar(
+    value: torch.Tensor | None, name: str, *, minimum: float | None = None, maximum: float | None = None
+) -> float | None:
+    if value is None:
+        return None
+    if value.numel() != 1 or not torch.isfinite(value).all():
+        raise ValueError(f"{name} must be one finite scalar when present.")
+    scalar = float(value.item())
+    if minimum is not None and scalar < minimum or maximum is not None and scalar > maximum:
+        raise ValueError(f"{name} must be in [{minimum}, {maximum}].")
+    return scalar
+
+
+def _competition_ranks(values: list[float]) -> tuple[int, ...]:
+    return tuple(1 + sum(other > value for other in values) for value in values)
+
+
+def _optional_action_ranks(actions: tuple[RootAction, ...]) -> Mapping[str, int | None]:
+    if not actions or any(action.statistics.visits is None for action in actions):
+        return {action.statistics.move: None for action in actions}
+    values = [float(action.statistics.visits or 0) for action in actions]
+    return {action.statistics.move: rank for action, rank in zip(actions, _competition_ranks(values))}
+
+
+def _search_action_comparison(
+    action: RootAction,
+    evaluator: EvaluatorAction,
+    conditional: Mapping[str, float],
+    shares: Mapping[str, float],
+    ranks: Mapping[str, int | None],
+) -> SearchActionComparison:
+    move = action.statistics.move
+    share = shares.get(move)
+    probability = conditional[move]
+    amplification = share / probability if share is not None and probability > 0 else None
+    return SearchActionComparison(
+        move,
+        evaluator.probability,
+        evaluator.rank,
+        action.statistics.prior,
+        action.statistics.visits,
+        share,
+        share - probability if share is not None else None,
+        amplification,
+        ranks[move],
+        action.statistics.perspective,
+        action.statistics.mean_value,
+        action.principal_variation,
+    )
+
+
+def _snapshot_behavior(
+    sequence: int,
+    budget: SearchBudget | None,
+    selected_move: str | None,
+    actions: tuple[RootAction, ...],
+) -> SearchSnapshotBehavior:
+    ranks = _optional_action_ranks(actions)
+    return SearchSnapshotBehavior(
+        sequence,
+        budget,
+        selected_move,
+        tuple((action.statistics.move, ranks[action.statistics.move]) for action in actions),
+        tuple((action.statistics.move, action.statistics.mean_value) for action in actions),
+    )
+
+
+def _discovery_budgets(trace: SearchTrace) -> tuple[tuple[str, SearchBudget | None], ...]:
+    if not trace.supports(SearchCapability.ROOT_SNAPSHOTS):
+        return ()
+    moves = sorted({action.statistics.move for snapshot in trace.snapshots for action in snapshot.actions or ()})
+    result = []
+    for move in moves:
+        budget = next(
+            (
+                snapshot.budget
+                for snapshot in trace.snapshots
+                for action in snapshot.actions or ()
+                if action.statistics.move == move and (action.statistics.visits or 0) > 0
+            ),
+            None,
+        )
+        result.append((move, budget))
+    return tuple(result)
+
+
+def _pv_stability(trace: SearchTrace) -> tuple[tuple[str, float | None], ...]:
+    if not trace.supports(SearchCapability.ROOT_SNAPSHOTS):
+        return ()
+    moves = sorted({action.statistics.move for snapshot in trace.snapshots for action in snapshot.actions or ()})
+    result = []
+    for move in moves:
+        pvs = [
+            action.principal_variation.moves
+            for snapshot in trace.snapshots
+            for action in snapshot.actions or ()
+            if action.statistics.move == move and action.principal_variation is not None
+        ]
+        scores = [_prefix_stability(before, after) for before, after in zip(pvs, pvs[1:])]
+        result.append((move, sum(scores) / len(scores) if scores else None))
+    return tuple(result)
+
+
+def _prefix_stability(before: tuple[str, ...], after: tuple[str, ...]) -> float:
+    common = 0
+    for left, right in zip(before, after):
+        if left != right:
+            break
+        common += 1
+    return common / max(len(before), len(after))
+
+
+def _target_effect(
+    move: str,
+    original: EvaluatorBehavior,
+    modified: EvaluatorBehavior,
+    before: EvaluatorAction | None,
+    after: EvaluatorAction | None,
+) -> TargetEffect:
+    before_probability = before.probability if before else None
+    after_probability = after.probability if after else None
+    return TargetEffect(
+        move,
+        before_probability,
+        after_probability,
+        after_probability - before_probability
+        if before_probability is not None and after_probability is not None
+        else None,
+        before.rank if before else None,
+        after.rank if after else None,
+        after.rank - before.rank if before and after else None,
+        original.selected_move == move,
+        modified.selected_move == move,
+    )
+
+
+__all__ = [
+    "BehaviorMetric",
+    "CollateralEffect",
+    "ControlKind",
+    "CounterfactualBehaviorComparison",
+    "DecisionComparison",
+    "EvaluatorAction",
+    "EvaluatorBehavior",
+    "METRIC_DEFINITIONS",
+    "MetricDefinition",
+    "SearchActionComparison",
+    "SearchBehaviorComparison",
+    "SearchEventBehavior",
+    "SearchSnapshotBehavior",
+    "TargetEffect",
+    "compare_counterfactual_behavior",
+    "compare_evaluator_to_search",
+    "compare_search_decision",
+    "compare_search_events",
+    "evaluator_behavior",
+]

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -152,6 +152,11 @@ def test_raw_evaluator_preference_compares_separately_with_reference_and_officia
     assert official_comparison.capability is SearchCapability.ROOT_SNAPSHOTS
     assert official_comparison.evaluator_probability_coverage < 1.0
     assert compare_search_events(reference, validate_replay=True).replay_validated
+    reordered = replace(
+        reference,
+        snapshots=(replace(reference.snapshots[-1], actions=tuple(reversed(reference.snapshots[-1].actions or ()))),),
+    )
+    assert compare_search_events(reordered, validate_replay=True).replay_validated
     with pytest.raises(SearchCapabilityError):
         compare_search_events(official)
 
@@ -326,6 +331,21 @@ def test_root_comparisons_reject_mismatches_and_retain_unavailable_statistics():
     assert comparison.action("e2e4").visit_share is None
     assert comparison.discovery_budgets == comparison.pv_stability == ()
 
+    unbudgeted_evolution = SearchTrace(
+        ROOT_FEN,
+        ChessPlayer.WHITE,
+        SearchCapability.ROOT_ACTION_STATS,
+        SearchProvenance("synthetic-unbudgeted-evolution"),
+        (
+            RootSnapshot(0, RootSelection("e2e4", "fixture", "fixture"), actions=(root_action,)),
+            RootSnapshot(1, RootSelection("e2e4", "fixture", "fixture"), actions=(root_action,)),
+        ),
+    )
+    no_evolution = compare_evaluator_to_search(evaluator, unbudgeted_evolution)
+    assert no_evolution.snapshots == ()
+    assert no_evolution.selected_move_changes == ()
+    assert no_evolution.discovery_budgets == no_evolution.pv_stability == ()
+
     empty_actions = SearchTrace(
         ROOT_FEN,
         ChessPlayer.WHITE,
@@ -393,6 +413,12 @@ def test_counterfactual_comparison_rejects_invalid_controls_links_and_evidence()
     with pytest.raises(ValueError, match="begin with"):
         compare_counterfactual_behavior(
             behavior, behavior, ("e2e4",), variation_evidence={"e2e4": replace(variation, deltas=())}
+        )
+    unrelated = LczeroBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 12 7")
+    unrelated_variation = analyze_variation(unrelated, (chess.Move.from_uci("e2e4"),), MaterialAnalyzer())
+    with pytest.raises(ValueError, match="original or modified evaluator FEN"):
+        compare_counterfactual_behavior(
+            behavior, behavior, ("e2e4",), variation_evidence={"e2e4": unrelated_variation}
         )
 
 

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -1,0 +1,232 @@
+"""Synthetic positive, null, and failure cases for observable behaviour."""
+
+from pathlib import Path
+
+import chess
+import pytest
+import torch
+from tensordict import TensorDict
+
+from lczerolens import LczeroBoard
+from lczerolens.behavior import (
+    BehaviorMetric,
+    ControlKind,
+    METRIC_DEFINITIONS,
+    compare_counterfactual_behavior,
+    compare_evaluator_to_search,
+    compare_search_decision,
+    compare_search_events,
+    evaluator_behavior,
+)
+from lczerolens.facts import FactPerspective, MaterialAnalyzer
+from lczerolens.lc0_adapter import Lc0RootSnapshotParser, Lc0SearchRequest
+from lczerolens.move_evidence import analyze_variation
+from lczerolens.reference_search import ReferenceMCTS
+from lczerolens.search_trace import (
+    ChessPlayer,
+    EdgeStatistics,
+    PrincipalVariation,
+    RootAction,
+    RootSelection,
+    RootSnapshot,
+    SearchBudget,
+    SearchBudgetUnit,
+    SearchCapability,
+    SearchCapabilityError,
+    SearchProvenance,
+    SearchTrace,
+    ValuePerspective,
+)
+
+
+ROOT_FEN = chess.STARTING_FEN
+
+
+def output_for(board, logits, *, value=None, wdl=None, mlh=None):
+    policy = torch.full((1858,), -10.0)
+    for move, logit in logits.items():
+        policy[board.encode_move(chess.Move.from_uci(move), board.turn)] = logit
+    values = {"policy": policy}
+    if value is not None:
+        values["value"] = torch.tensor(value)
+    if wdl is not None:
+        values["wdl"] = torch.tensor(wdl)
+    if mlh is not None:
+        values["mlh"] = torch.tensor(mlh)
+    return TensorDict(values)
+
+
+class FixedEvaluator:
+    def __call__(self, board):
+        ranked = {
+            move.uci(): float(rank) for rank, move in enumerate(sorted(board.legal_moves, key=lambda item: item.uci()))
+        }
+        if board.fen() == ROOT_FEN:
+            ranked |= {"e2e4": 30.0, "d2d4": 20.0}
+        return output_for(board, ranked, value=0.2)
+
+
+def test_evaluator_behavior_masks_illegal_moves_and_defines_optional_heads_and_ties():
+    board = LczeroBoard()
+    output = output_for(board, {"e2e4": 3.0, "d2d4": 3.0}, value=0.25, wdl=(0.5, 0.3, 0.2), mlh=17)
+    illegal_index = next(index for index in range(1858) if index not in set(board.get_legal_indices().tolist()))
+    output["policy"][illegal_index] = 100.0
+
+    behavior = evaluator_behavior(board, output)
+
+    assert behavior.selection_ties == ("d2d4", "e2e4")
+    assert behavior.selected_move == "d2d4"
+    assert behavior.action("e7e5") is None
+    assert behavior.action("d2d4").rank == behavior.action("e2e4").rank == 1
+    assert sum(action.probability for action in behavior.actions) == pytest.approx(1.0)
+    assert behavior.evaluation.wdl.scalar() == pytest.approx(0.3)
+    assert behavior.mlh == 17
+
+
+def test_counterfactual_comparison_separates_positive_target_and_collateral_effects():
+    board = LczeroBoard()
+    original = evaluator_behavior(board, output_for(board, {"e2e4": 4.0, "d2d4": 2.0}))
+    modified = evaluator_behavior(board, output_for(board, {"e2e4": 1.0, "d2d4": 4.0}))
+
+    comparison = compare_counterfactual_behavior(original, modified, ("e2e4",), control_kind=ControlKind.MATCHED)
+
+    assert comparison.targets[0].probability_delta < 0
+    assert comparison.targets[0].rank_delta > 0
+    assert "e2e4" not in comparison.collateral.moves
+    assert comparison.collateral.probability_total_variation > 0
+
+
+@pytest.mark.parametrize("kind", tuple(ControlKind))
+def test_null_controls_are_first_class_structured_outputs(kind):
+    board = LczeroBoard()
+    behavior = evaluator_behavior(board, output_for(board, {"e2e4": 2.0}))
+
+    comparison = compare_counterfactual_behavior(behavior, behavior, ("e2e4",), control_kind=kind)
+
+    assert comparison.control_kind is kind
+    assert comparison.targets[0].probability_delta == 0
+    assert comparison.collateral.probability_total_variation == 0
+
+
+def test_failures_are_explicit_for_missing_heads_bad_targets_and_capabilities():
+    board = LczeroBoard()
+    with pytest.raises(ValueError, match="missing required 'policy'"):
+        evaluator_behavior(board, TensorDict({"value": torch.tensor(0.0)}))
+    behavior = evaluator_behavior(board, output_for(board, {"e2e4": 1.0}))
+    with pytest.raises(ValueError, match="target_moves"):
+        compare_counterfactual_behavior(behavior, behavior, ())
+
+    root_result = Lc0RootSnapshotParser().parse(
+        ["bestmove e2e4"],
+        request=Lc0SearchRequest(ROOT_FEN, nodes=1),
+        engine_version="test",
+        network="test",
+    )
+    with pytest.raises(SearchCapabilityError):
+        compare_evaluator_to_search(behavior, root_result)
+    with pytest.raises(SearchCapabilityError):
+        compare_search_events(root_result)
+
+
+def test_raw_evaluator_preference_compares_separately_with_reference_and_official_lc0():
+    board = LczeroBoard()
+    evaluator = evaluator_behavior(board, FixedEvaluator()(board))
+    reference = ReferenceMCTS(c_puct=1.0).search(board, FixedEvaluator(), simulations=4)
+    fixture = Path(__file__).parents[1] / "assets" / "lc0_root_snapshot_v1.txt"
+    official = Lc0RootSnapshotParser().parse(
+        fixture.read_text().splitlines(),
+        request=Lc0SearchRequest(ROOT_FEN, nodes=256, options={"VerboseMoveStats": True}),
+        engine_version="v0.31.2",
+        network="fixture",
+    )
+
+    reference_comparison = compare_evaluator_to_search(evaluator, reference)
+    official_comparison = compare_evaluator_to_search(evaluator, official)
+
+    assert reference_comparison.source == "lczerolens-reference-mcts"
+    assert reference_comparison.capability is SearchCapability.REPLAYABLE
+    assert official_comparison.source == "official_lc0_uci"
+    assert official_comparison.capability is SearchCapability.ROOT_SNAPSHOTS
+    assert official_comparison.evaluator_probability_coverage < 1.0
+    assert compare_search_events(reference, validate_replay=True).replay_validated
+    with pytest.raises(SearchCapabilityError):
+        compare_search_events(official)
+
+
+def test_budgeted_snapshots_report_rank_q_selection_discovery_and_pv_evolution():
+    board = LczeroBoard()
+    evaluator = evaluator_behavior(board, output_for(board, {"e2e4": 3.0, "d2d4": 2.0}))
+
+    def action(move, visits, q, pv):
+        return RootAction(
+            EdgeStatistics(move, ValuePerspective.ROOT_PLAYER, prior=0.5, visits=visits, mean_value=q),
+            principal_variation=PrincipalVariation(pv),
+        )
+
+    trace = SearchTrace(
+        ROOT_FEN,
+        ChessPlayer.WHITE,
+        SearchCapability.ROOT_SNAPSHOTS,
+        SearchProvenance("synthetic-root-snapshots"),
+        (
+            RootSnapshot(
+                0,
+                RootSelection("e2e4", "fixture", "fixture"),
+                budget=SearchBudget(SearchBudgetUnit.NODES, observed=0),
+                actions=(action("e2e4", 0, 0.0, ("e2e4", "e7e5")), action("d2d4", 0, 0.0, ("d2d4", "d7d5"))),
+            ),
+            RootSnapshot(
+                1,
+                RootSelection("d2d4", "fixture", "fixture"),
+                budget=SearchBudget(SearchBudgetUnit.NODES, observed=3),
+                actions=(action("e2e4", 1, 0.2, ("e2e4", "c7c5")), action("d2d4", 2, 0.5, ("d2d4", "d7d5"))),
+            ),
+        ),
+    )
+
+    comparison = compare_evaluator_to_search(evaluator, trace)
+
+    assert comparison.snapshots[0].ranks == (("e2e4", 1), ("d2d4", 1))
+    assert comparison.snapshots[1].q_values == (("e2e4", 0.2), ("d2d4", 0.5))
+    assert comparison.selected_move_changes == ((1, "e2e4", "d2d4"),)
+    assert all(budget.observed == 3 for _, budget in comparison.discovery_budgets)
+    assert dict(comparison.pv_stability) == {"d2d4": 1.0, "e2e4": 0.5}
+
+
+def test_decision_comparison_links_both_candidates_to_variation_evidence():
+    board = LczeroBoard()
+    evaluator = evaluator_behavior(board, output_for(board, {"e2e4": 4.0, "d2d4": 2.0}))
+    trace = ReferenceMCTS(c_puct=0.0).search(board, FixedEvaluator(), simulations=1)
+    search_move = trace.snapshots[-1].selection.move
+    evidence = {
+        move: analyze_variation(
+            board,
+            (chess.Move.from_uci(move),),
+            MaterialAnalyzer(FactPerspective.WHITE),
+            MaterialAnalyzer(FactPerspective.BLACK),
+        )
+        for move in (evaluator.selected_move, search_move)
+    }
+
+    decision = compare_search_decision(evaluator, trace, variation_evidence=evidence)
+
+    assert decision.evaluator_candidate == "e2e4"
+    assert decision.search_candidate == search_move
+    assert decision.evaluator_variation.moves[0].uci() == "e2e4"
+    assert decision.search_variation.moves[0].uci() == search_move
+
+
+def test_every_metric_definition_states_all_required_semantics():
+    assert set(METRIC_DEFINITIONS) == set(BehaviorMetric)
+    for definition in METRIC_DEFINITIONS.values():
+        assert all(
+            (
+                definition.perspective,
+                definition.normalization,
+                definition.aggregation,
+                definition.ties,
+                definition.missing_or_illegal,
+            )
+        )
+    assert METRIC_DEFINITIONS[BehaviorMetric.EVENT_PATH_DEPTH].required_capability is SearchCapability.FULL_EVENTS
+    assert METRIC_DEFINITIONS[BehaviorMetric.REPLAY_VALIDATION].required_capability is SearchCapability.REPLAYABLE

--- a/tests/unit/test_behavior.py
+++ b/tests/unit/test_behavior.py
@@ -1,5 +1,6 @@
 """Synthetic positive, null, and failure cases for observable behaviour."""
 
+from dataclasses import replace
 from pathlib import Path
 
 import chess
@@ -18,6 +19,7 @@ from lczerolens.behavior import (
     compare_search_events,
     evaluator_behavior,
 )
+from lczerolens.counterfactuals import remove_piece_counterfactual
 from lczerolens.facts import FactPerspective, MaterialAnalyzer
 from lczerolens.lc0_adapter import Lc0RootSnapshotParser, Lc0SearchRequest
 from lczerolens.move_evidence import analyze_variation
@@ -25,6 +27,7 @@ from lczerolens.reference_search import ReferenceMCTS
 from lczerolens.search_trace import (
     ChessPlayer,
     EdgeStatistics,
+    PositionEvaluation,
     PrincipalVariation,
     RootAction,
     RootSelection,
@@ -230,3 +233,181 @@ def test_every_metric_definition_states_all_required_semantics():
         )
     assert METRIC_DEFINITIONS[BehaviorMetric.EVENT_PATH_DEPTH].required_capability is SearchCapability.FULL_EVENTS
     assert METRIC_DEFINITIONS[BehaviorMetric.REPLAY_VALIDATION].required_capability is SearchCapability.REPLAYABLE
+
+
+@pytest.mark.parametrize(
+    ("board", "output", "perspective", "message"),
+    [
+        (chess.Board(), {"policy": torch.zeros(1858)}, ValuePerspective.SIDE_TO_MOVE, "LczeroBoard"),
+        (LczeroBoard(), {"policy": torch.zeros(1858)}, "white", "ValuePerspective"),
+        (LczeroBoard(), {"policy": torch.zeros(17)}, ValuePerspective.SIDE_TO_MOVE, "1858 finite"),
+        (
+            LczeroBoard(),
+            {"policy": torch.full((1858,), float("nan"))},
+            ValuePerspective.SIDE_TO_MOVE,
+            "1858 finite",
+        ),
+        (
+            LczeroBoard("7k/6Q1/6K1/8/8/8/8/8 b - - 0 1"),
+            {"policy": torch.zeros(1858)},
+            ValuePerspective.SIDE_TO_MOVE,
+            "non-terminal",
+        ),
+        (
+            LczeroBoard(),
+            {"policy": torch.zeros(1858), "wdl": torch.zeros(2)},
+            ValuePerspective.SIDE_TO_MOVE,
+            "exactly",
+        ),
+        (LczeroBoard(), {"policy": "not a tensor"}, ValuePerspective.SIDE_TO_MOVE, "must be a tensor"),
+        (
+            LczeroBoard(),
+            {"policy": torch.zeros(1858), "value": torch.tensor((0.0, 0.1))},
+            ValuePerspective.SIDE_TO_MOVE,
+            "one finite scalar",
+        ),
+        (
+            LczeroBoard(),
+            {"policy": torch.zeros(1858), "mlh": torch.tensor(float("nan"))},
+            ValuePerspective.SIDE_TO_MOVE,
+            "one finite scalar",
+        ),
+        (
+            LczeroBoard(),
+            {"policy": torch.zeros(1858), "value": torch.tensor(1.1)},
+            ValuePerspective.SIDE_TO_MOVE,
+            r"in \[-1.0, 1.0\]",
+        ),
+        (
+            LczeroBoard(),
+            {"policy": torch.zeros(1858), "value": torch.tensor(-1.1)},
+            ValuePerspective.SIDE_TO_MOVE,
+            r"in \[-1.0, 1.0\]",
+        ),
+    ],
+)
+def test_evaluator_behavior_rejects_malformed_inputs_and_optional_heads(board, output, perspective, message):
+    with pytest.raises((TypeError, ValueError), match=message):
+        evaluator_behavior(board, output, perspective=perspective)
+
+
+def test_evaluator_behavior_accepts_singleton_batched_heads():
+    board = LczeroBoard()
+    output = TensorDict(
+        {
+            "policy": torch.zeros((1, 1858)),
+            "value": torch.tensor((0.25,)),
+            "wdl": torch.tensor(((0.5, 0.3, 0.2),)),
+            "mlh": torch.tensor((12.0,)),
+        },
+        batch_size=[1],
+    )
+
+    behavior = evaluator_behavior(board, output)
+
+    assert behavior.evaluation.value == pytest.approx(0.25)
+    assert behavior.mlh == 12.0
+
+
+def test_root_comparisons_reject_mismatches_and_retain_unavailable_statistics():
+    board = LczeroBoard()
+    evaluator = evaluator_behavior(board, output_for(board, {"e2e4": 3.0}))
+    root_action = RootAction(EdgeStatistics("e2e4", ValuePerspective.ROOT_PLAYER, prior=1.0))
+    action_only = SearchTrace(
+        ROOT_FEN,
+        ChessPlayer.WHITE,
+        SearchCapability.ROOT_ACTION_STATS,
+        SearchProvenance("synthetic-actions"),
+        (RootSnapshot(0, RootSelection("e2e4", "fixture", "fixture"), actions=(root_action,)),),
+    )
+
+    comparison = compare_evaluator_to_search(evaluator, action_only)
+    assert comparison.action("e2e4").search_rank is None
+    assert comparison.action("e2e4").visit_share is None
+    assert comparison.discovery_budgets == comparison.pv_stability == ()
+
+    empty_actions = SearchTrace(
+        ROOT_FEN,
+        ChessPlayer.WHITE,
+        SearchCapability.ROOT_ACTION_STATS,
+        SearchProvenance("synthetic-empty-actions"),
+        (RootSnapshot(0, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0), actions=()),),
+    )
+    empty_comparison = compare_evaluator_to_search(evaluator, empty_actions)
+    assert empty_comparison.actions == ()
+    with pytest.raises(ValueError, match="selection"):
+        compare_search_decision(evaluator, empty_actions)
+
+    other = LczeroBoard()
+    other.push_uci("e2e4")
+    other_evaluator = evaluator_behavior(other, output_for(other, {"e7e5": 1.0}))
+    with pytest.raises(ValueError, match="same root FEN"):
+        compare_evaluator_to_search(other_evaluator, action_only)
+    absolute = replace(evaluator, perspective=ValuePerspective.WHITE)
+    with pytest.raises(ValueError, match="side-to-move or root-player"):
+        compare_evaluator_to_search(absolute, action_only)
+
+    evaluator_without_exposed_candidate = evaluator_behavior(board, output_for(board, {"g1h3": 20.0}))
+    with pytest.raises(ValueError, match="Both evaluator and search candidates"):
+        compare_search_decision(evaluator_without_exposed_candidate, action_only)
+
+
+def test_counterfactual_comparison_rejects_invalid_controls_links_and_evidence():
+    board = LczeroBoard()
+    behavior = evaluator_behavior(board, output_for(board, {"e2e4": 2.0}))
+    variation = analyze_variation(board, (chess.Move.from_uci("e2e4"),), MaterialAnalyzer())
+    other_variation = analyze_variation(board, (chess.Move.from_uci("d2d4"),), MaterialAnalyzer())
+
+    linked = compare_counterfactual_behavior(
+        behavior,
+        behavior,
+        ("e2e4",),
+        variation_evidence={"e2e4": variation, "d2d4": other_variation},
+    )
+    assert dict(linked.variation_evidence) == {"d2d4": other_variation, "e2e4": variation}
+
+    with pytest.raises(ValueError, match="ControlKind"):
+        compare_counterfactual_behavior(behavior, behavior, ("e2e4",), control_kind="matched")
+    with pytest.raises(ValueError, match="same perspective"):
+        compare_counterfactual_behavior(
+            behavior, replace(behavior, perspective=ValuePerspective.ROOT_PLAYER), ("e2e4",)
+        )
+    black_board = LczeroBoard()
+    black_board.push_uci("e2e4")
+    black_behavior = evaluator_behavior(black_board, output_for(black_board, {"e7e5": 1.0}))
+    with pytest.raises(ValueError, match="absolute side"):
+        compare_counterfactual_behavior(behavior, black_behavior, ("e2e4",))
+    with pytest.raises(ValueError, match="Invalid target UCI"):
+        compare_counterfactual_behavior(behavior, behavior, ("invalid",))
+
+    failed = remove_piece_counterfactual(board, chess.E4)
+    with pytest.raises(ValueError, match="must have succeeded"):
+        compare_counterfactual_behavior(behavior, behavior, ("e2e4",), counterfactual=failed)
+    mismatched = remove_piece_counterfactual(board, chess.A2)
+    with pytest.raises(ValueError, match="must match"):
+        compare_counterfactual_behavior(behavior, behavior, ("e2e4",), counterfactual=mismatched)
+    with pytest.raises(ValueError, match="target or collateral"):
+        compare_counterfactual_behavior(behavior, behavior, ("e2e4",), variation_evidence={"a1a8": variation})
+    with pytest.raises(ValueError, match="begin with"):
+        compare_counterfactual_behavior(behavior, behavior, ("e2e4",), variation_evidence={"d2d4": variation})
+    with pytest.raises(ValueError, match="begin with"):
+        compare_counterfactual_behavior(
+            behavior, behavior, ("e2e4",), variation_evidence={"e2e4": replace(variation, deltas=())}
+        )
+
+
+def test_decision_evidence_and_non_replay_event_paths_fail_explicitly():
+    board = LczeroBoard()
+    evaluator = evaluator_behavior(board, output_for(board, {"e2e4": 3.0}))
+    trace = ReferenceMCTS().search(board, FixedEvaluator(), simulations=1)
+    variation = analyze_variation(board, (chess.Move.from_uci("e2e4"),), MaterialAnalyzer())
+
+    assert compare_search_events(trace).replay_validated is None
+    with pytest.raises(ValueError, match="start at the root"):
+        compare_search_decision(evaluator, trace, variation_evidence={"d2d4": variation})
+
+    wrong_root = LczeroBoard()
+    wrong_root.push_uci("e2e4")
+    wrong_root_variation = analyze_variation(wrong_root, (chess.Move.from_uci("e7e5"),), MaterialAnalyzer())
+    with pytest.raises(ValueError, match="start at the root"):
+        compare_search_decision(evaluator, trace, variation_evidence={"e7e5": wrong_root_variation})


### PR DESCRIPTION
## Summary

- add typed evaluator behavior records with legal masking, legal softmax probabilities, competition ranks, explicit ties, and optional value/WDL/MLH heads
- add capability-aware root search comparisons for divergence, visit amplification, rank/Q evolution, selection changes, discovery budgets, and PV stability
- separate full-event and replay validation metrics from root-only comparisons
- add target-versus-collateral counterfactual effects, structured matched/shuffled/wrong-target controls, and evidence-linked decision comparisons
- document every metric's perspective, normalization, aggregation, tie, missing-action, and capability contract

## Why

Issue #134 needs a reusable observable-behavior boundary that can compare evaluator and search evidence without owning attribution methods or treating reference MCTS and official lc0 as equivalent searches.

## Impact

Consumers can now standardize evaluator outputs, compare them with any compatible `SearchTrace`, retain control and chess-evidence links, and receive explicit capability failures when a requested claim exceeds the source trace.

## Validation

- `just checks`
- `just tests` — 229 passed, 12 deselected, 88% total coverage
- `just docs` — succeeded; existing duplicate-object and generated-notebook toctree warnings remain

Closes #134