### PR TITLE
Docs: add end-to-end decision-analysis tutorial

### DIFF
--- a/docs/source/decision-analysis-tutorial.rst
+++ b/docs/source/decision-analysis-tutorial.rst
@@ -1,0 +1,64 @@
+End-to-end decision analysis
+============================
+
+This maintained tutorial validates the complete product boundary with one
+reproducible decision-analysis workflow. It intentionally uses a tiny,
+versioned PyTorch fixture rather than a downloaded network: its observations
+are demonstrations of API composition, **not scientific conclusions about
+chess or a trained model**.
+
+Run it from a clean environment with the development group installed::
+
+   uv sync --group dev
+   uv run pytest -q -m integration tests/integration/test_decision_analysis_tutorial.py
+
+The test is an explicit integration tier, so normal unit runs do not silently
+present this tutorial as model validation. The fixture is defined alongside the
+tutorial and has only the standard ``policy`` and ``value`` TensorDict heads.
+
+The workflow
+------------
+
+The executable companion is :download:`examples/decision_analysis_tutorial.py
+<../../examples/decision_analysis_tutorial.py>`. Its ``run_tutorial`` function:
+
+#. wraps a small PyTorch module in :class:`~lczerolens.model.LczeroModel`, the
+   same TensorDict evaluator boundary used for an lc0-family model loaded from
+   ONNX, Torch, or the Hub;
+#. evaluates the initial position after masking to legal candidates;
+#. runs :class:`~lczerolens.reference_search.ReferenceMCTS` and retains its
+   capability-aware :class:`~lczerolens.search_trace.SearchTrace`;
+#. attaches exact material variation evidence to the evaluator and search
+   candidates;
+#. makes a constrained sibling-move counterfactual (``g1f3`` versus ``b1c3``);
+#. reports the target ``e7e5`` effect separately from the collateral legal
+   action distribution; and
+#. records whether evaluator and reference-search candidates agree, including
+   their root statistics and variation evidence.
+
+The reference search is explicitly ``replayable`` and therefore exposes full
+events. That is stronger than an official-lc0 adapter that only advertises
+root snapshots. Do not use this tutorial to claim that the two searches are
+algorithmically equivalent, or that root-only output contains event evidence.
+
+Optional external instrumentation
+---------------------------------
+
+An attribution or hook library belongs *around* ``model`` in
+``load_fixture_evaluator``/``evaluate``. For example, an application can wrap
+the returned ``LczeroModel`` with a tdhook or Captum session, then preserve the
+same ``TensorDict`` output for ``evaluator_behavior`` and ``ReferenceMCTS``.
+Removing that optional wrapper changes neither the chess-evidence nor the
+search-analysis APIs. The maintained executable deliberately does not depend
+on an interpretability package, so the product boundary remains reproducible
+with the documented development environment.
+
+Reading the result
+------------------
+
+``TutorialResult`` retains structured records instead of prose explanations:
+the raw evaluator preference, the search decision comparison, exact variation
+evidence, the counterfactual validity tier, one target-move delta, and the
+collateral distribution shift. Those are observations with provenance. They
+can motivate a research question, but they do not establish a causal mechanism,
+model strength, or general chess conclusion.

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -27,6 +27,8 @@ Supported user path
 * :doc:`search` defines typed, capability-aware traces. ``ReferenceMCTS`` is
   an auditable reference implementation, not production lc0 search.
 * :doc:`behavior` covers evaluator, counterfactual, and search comparisons.
+* :doc:`decision-analysis-tutorial` runs those public boundaries together with
+  a small versioned fixture; its output is a demonstration, not a result.
 * :doc:`api/index` contains generated reference documentation for every
   importable module.
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -14,10 +14,15 @@ the automated-interpretability and learned-look-ahead notebooks remain
 incomplete. Neural-method examples are external integrations, not an
 lczerolens-owned API or methodological guarantee.
 
+The maintained :doc:`decision-analysis-tutorial` is the one reproducible
+end-to-end product-validation workflow. It uses a small versioned fixture and
+is executed in the explicit integration test tier.
+
 .. toctree::
    :hidden:
    :maxdepth: 2
 
+   decision-analysis-tutorial
    notebooks/walkthrough.ipynb
    notebooks/tutorials/framework-agnostic-interpretability.ipynb
    notebooks/tutorials/automated-interpretability.ipynb

--- a/examples/decision_analysis_tutorial.py
+++ b/examples/decision_analysis_tutorial.py
@@ -100,12 +100,12 @@ def run_tutorial() -> TutorialResult:
 
     counterfactual = sibling_counterfactual(board, chess.Move.from_uci("g1f3"), chess.Move.from_uci("b1c3"))
     assert counterfactual.modified is not None
-    original = evaluator_behavior(
-        LczeroBoard(counterfactual.original.fen), evaluate(model, LczeroBoard(counterfactual.original.fen))
-    )
-    modified = evaluator_behavior(
-        LczeroBoard(counterfactual.modified.fen), evaluate(model, LczeroBoard(counterfactual.modified.fen))
-    )
+    original_board = board.copy(stack=True)
+    original_board.push_uci("g1f3")
+    modified_board = board.copy(stack=True)
+    modified_board.push_uci("b1c3")
+    original = evaluator_behavior(original_board, evaluate(model, original_board))
+    modified = evaluator_behavior(modified_board, evaluate(model, modified_board))
     comparison = compare_counterfactual_behavior(
         original,
         modified,
@@ -113,7 +113,7 @@ def run_tutorial() -> TutorialResult:
         counterfactual=counterfactual,
         variation_evidence={
             "e7e5": analyze_variation(
-                LczeroBoard(counterfactual.original.fen),
+                original_board,
                 (chess.Move.from_uci("e7e5"),),
                 MaterialAnalyzer(FactPerspective.WHITE),
             )

--- a/examples/decision_analysis_tutorial.py
+++ b/examples/decision_analysis_tutorial.py
@@ -1,0 +1,127 @@
+"""Executable companion for the end-to-end decision-analysis tutorial.
+
+The tiny deterministic module is a versioned fixture, not a chess model or a
+scientific result.  It makes the public evaluator, evidence, search, and
+comparison boundaries runnable without downloading weights or an engine.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import chess
+import torch
+from tensordict import TensorDict
+from torch import nn
+
+from lczerolens import LczeroBoard
+from lczerolens.behavior import (
+    CounterfactualBehaviorComparison,
+    DecisionComparison,
+    EvaluatorBehavior,
+    compare_counterfactual_behavior,
+    compare_search_decision,
+    evaluator_behavior,
+)
+from lczerolens.counterfactuals import CounterfactualResult, sibling_counterfactual
+from lczerolens.facts import FactPerspective, MaterialAnalyzer
+from lczerolens.model import LczeroModel
+from lczerolens.move_evidence import VariationEvidence, analyze_variation
+from lczerolens.reference_search import ReferenceMCTS
+from lczerolens.search_trace import SearchTrace
+
+
+class _TutorialFixtureModule(nn.Module):
+    """Small PyTorch fixture with the same heads consumed by the public API."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        root = LczeroBoard()
+        after_e4 = root.copy(stack=True)
+        after_e4.push_uci("e2e4")
+        self.register_buffer("root_e4", torch.tensor(root.encode_move(chess.Move.from_uci("e2e4"), root.turn)))
+        self.register_buffer("root_d4", torch.tensor(root.encode_move(chess.Move.from_uci("d2d4"), root.turn)))
+        self.register_buffer(
+            "black_e5", torch.tensor(after_e4.encode_move(chess.Move.from_uci("e7e5"), after_e4.turn))
+        )
+
+    def forward(self, board: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        batch = board.shape[0]
+        policy = torch.zeros((batch, 1858), device=board.device)
+        # A deliberately transparent position-dependent score.  It is only a
+        # fixture mechanism, not an interpretation of chess features.
+        file_signal = (board * torch.arange(8, device=board.device).view(1, 1, 1, 8)).sum((1, 2, 3))
+        policy[:, self.root_e4] = 4.0
+        policy[:, self.root_d4] = 2.0
+        policy[:, self.black_e5] = file_signal
+        return policy, torch.full((batch,), 0.2, device=board.device)
+
+
+def load_fixture_evaluator() -> LczeroModel:
+    """Load a tiny PyTorch evaluator through the standard TensorDict wrapper."""
+    return LczeroModel(_TutorialFixtureModule(), out_keys=["policy", "value"])
+
+
+def evaluate(model: LczeroModel, board: LczeroBoard) -> TensorDict:
+    """Adapt the public model output to the singleton evaluator search contract."""
+    return model(board)
+
+
+@dataclass(frozen=True)
+class TutorialResult:
+    """Structured observations from the tutorial, with no scientific claim."""
+
+    evaluator: EvaluatorBehavior
+    search: SearchTrace
+    decision: DecisionComparison
+    counterfactual: CounterfactualResult
+    counterfactual_behavior: CounterfactualBehaviorComparison
+    variations: dict[str, VariationEvidence]
+
+
+def run_tutorial() -> TutorialResult:
+    """Run the documented, hermetic decision-analysis workflow."""
+    board = LczeroBoard()
+    model = load_fixture_evaluator()
+    evaluator = evaluator_behavior(board, evaluate(model, board))
+    search = ReferenceMCTS(c_puct=1.0).search(board, lambda position: evaluate(model, position), simulations=4)
+
+    # The candidate lines are exact move evidence, not generated explanation.
+    variations = {
+        move: analyze_variation(
+            board,
+            (chess.Move.from_uci(move),),
+            MaterialAnalyzer(FactPerspective.WHITE),
+            MaterialAnalyzer(FactPerspective.BLACK),
+        )
+        for move in (evaluator.selected_move, search.snapshots[-1].selection.move)
+    }
+    decision = compare_search_decision(evaluator, search, variation_evidence=variations)
+
+    counterfactual = sibling_counterfactual(board, chess.Move.from_uci("g1f3"), chess.Move.from_uci("b1c3"))
+    assert counterfactual.modified is not None
+    original = evaluator_behavior(
+        LczeroBoard(counterfactual.original.fen), evaluate(model, LczeroBoard(counterfactual.original.fen))
+    )
+    modified = evaluator_behavior(
+        LczeroBoard(counterfactual.modified.fen), evaluate(model, LczeroBoard(counterfactual.modified.fen))
+    )
+    comparison = compare_counterfactual_behavior(
+        original,
+        modified,
+        ("e7e5",),
+        counterfactual=counterfactual,
+        variation_evidence={
+            "e7e5": analyze_variation(
+                LczeroBoard(counterfactual.original.fen),
+                (chess.Move.from_uci("e7e5"),),
+                MaterialAnalyzer(FactPerspective.WHITE),
+            )
+        },
+    )
+    return TutorialResult(evaluator, search, decision, counterfactual, comparison, variations)
+
+
+if __name__ == "__main__":
+    result = run_tutorial()
+    print(f"evaluator={result.evaluator.selected_move} search={result.decision.search_candidate}")

--- a/examples/decision_analysis_tutorial.py
+++ b/examples/decision_analysis_tutorial.py
@@ -99,7 +99,8 @@ def run_tutorial() -> TutorialResult:
     decision = compare_search_decision(evaluator, search, variation_evidence=variations)
 
     counterfactual = sibling_counterfactual(board, chess.Move.from_uci("g1f3"), chess.Move.from_uci("b1c3"))
-    assert counterfactual.modified is not None
+    if not counterfactual.succeeded or counterfactual.modified is None:
+        raise RuntimeError("The tutorial's legal sibling counterfactual unexpectedly failed.")
     original_board = board.copy(stack=True)
     original_board.push_uci("g1f3")
     modified_board = board.copy(stack=True)

--- a/tests/integration/test_decision_analysis_tutorial.py
+++ b/tests/integration/test_decision_analysis_tutorial.py
@@ -1,0 +1,17 @@
+"""The maintained tutorial is an explicit non-default integration tier."""
+
+import pytest
+
+from examples.decision_analysis_tutorial import run_tutorial
+from lczerolens.search_trace import SearchCapability
+
+
+@pytest.mark.integration
+def test_decision_analysis_tutorial_runs_from_its_versioned_fixture():
+    result = run_tutorial()
+
+    assert result.search.capability is SearchCapability.REPLAYABLE
+    assert result.decision.evaluator_variation is not None
+    assert result.decision.search_variation is not None
+    assert result.counterfactual.succeeded
+    assert result.counterfactual_behavior.targets[0].move == "e7e5"


### PR DESCRIPTION
## Summary

- add a maintained, executable decision-analysis tutorial with a small versioned TensorDict/PyTorch fixture
- exercise evaluator behavior, replayable reference search, move/variation evidence, sibling-move counterfactuals, and target/collateral behavior comparison
- link the tutorial from the public navigation and execute it in the explicit integration tier

The fixture demonstrates API composition only; it makes no scientific claim about a chess model or search strength.

Closes #135

## Validation

- `uv run --group dev pytest -q -m integration tests/integration/test_decision_analysis_tutorial.py`
- `uv run --group dev pre-commit run --files …`
- `just docs`