### PR TITLE
Add independent semantic replay for search traces

### DIFF
--- a/docs/source/search.rst
+++ b/docs/source/search.rst
@@ -224,6 +224,16 @@ The public :func:`~lczerolens.reference_search.replay_root_events` helper
 reconstructs final root statistics using events alone; it neither reads mutable
 tree state nor calls the search backup routine.
 
+For the stronger trace-faithfulness guarantee,
+:func:`~lczerolens.reference_search.replay_search_trace` independently rebuilds
+the deterministic reference tree from ``root_fen`` and the semantic event
+records. It redoes PUCT path selection, legal expansion, terminal evaluation,
+perspective-aware backups, root visit policy, and final move selection. Recorded
+root pre/post states and the final snapshot are divergence checks, not the state
+returned by replay. :class:`~lczerolens.reference_search.SemanticReplayError`
+identifies the first event and replay phase that disagree. This capability is
+specific to ``ReferenceMCTS`` and does not imply production-lc0 equivalence.
+
 The reference PUCT score is ``Q + c_puct * P * sqrt(sum(N)) / (1 + N)``.
 Exact score ties and zero-visit root selection use UCI lexicographic order;
 final root selection is maximum visit count at temperature zero. Search is

--- a/docs/source/search.rst
+++ b/docs/source/search.rst
@@ -227,7 +227,9 @@ tree state nor calls the search backup routine.
 For the stronger trace-faithfulness guarantee,
 :func:`~lczerolens.reference_search.replay_search_trace` independently rebuilds
 the deterministic reference tree from ``root_fen`` and the semantic event
-records. It redoes PUCT path selection, legal expansion, terminal evaluation,
+records. Reference traces retain the starting FEN and full root move history so
+history-dependent terminality, including fivefold repetition, is replayed from
+the same board state. It redoes PUCT path selection, legal expansion, terminal evaluation,
 perspective-aware backups, root visit policy, and final move selection. Recorded
 root pre/post states and the final snapshot are divergence checks, not the state
 returned by replay. :class:`~lczerolens.reference_search.SemanticReplayError`

--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -29,7 +29,13 @@ from .facts import Evidence, EvidenceSet, FactAnalyzer
 from .lc0_adapter import Lc0ProcessAdapter, Lc0RootSnapshotParser, Lc0SearchRequest
 from .model import LczeroModel
 from .move_evidence import MoveDelta, VariationEvidence, analyze_move_delta, analyze_variation
-from .reference_search import ReferenceMCTS, replay_root_events
+from .reference_search import (
+    ReferenceMCTS,
+    SemanticReplayError,
+    SemanticReplayResult,
+    replay_root_events,
+    replay_search_trace,
+)
 
 try:
     __version__ = version("lczerolens")
@@ -56,6 +62,8 @@ __all__ = [
     "MoveDelta",
     "PositionAttribute",
     "ReferenceMCTS",
+    "SemanticReplayError",
+    "SemanticReplayResult",
     "SearchBehaviorComparison",
     "VariationEvidence",
     "analyze_move_delta",
@@ -68,5 +76,6 @@ __all__ = [
     "relocate_piece_counterfactual",
     "remove_piece_counterfactual",
     "replay_root_events",
+    "replay_search_trace",
     "sibling_counterfactual",
 ]

--- a/src/lczerolens/reference_search.py
+++ b/src/lczerolens/reference_search.py
@@ -179,6 +179,8 @@ class ReferenceMCTS:
             events=tuple(events),
             root_expansion=root_expansion,
             root_evaluator=root_evaluator,
+            root_start_fen=root.board.root().fen(),
+            root_move_history=tuple(move.uci() for move in root.board.move_stack),
         )
 
     def _expand(
@@ -330,7 +332,7 @@ def replay_search_trace(trace: SearchTrace) -> SemanticReplayResult:
     if not events:
         raise SemanticReplayError("at least one simulation event is required.", phase="events")
     c_puct = _replay_c_puct(trace)
-    root_board = LczeroBoard(trace.root_fen)
+    root_board = _replay_root_board(trace)
     first = events[0]
     if not first.path:
         raise SemanticReplayError(
@@ -359,8 +361,6 @@ def replay_search_trace(trace: SearchTrace) -> SemanticReplayResult:
 
     root_statistics = _replay_edge_stats(root, ValuePerspective.ROOT_PLAYER)
     total_visits = sum(edge.visits or 0 for edge in root_statistics)
-    if total_visits <= 0:
-        raise SemanticReplayError("replayed root has no visits.", phase="result")
     root_policy = tuple((edge.move, (edge.visits or 0) / total_visits) for edge in root_statistics)
     best_visits = max(edge.visits or 0 for edge in root_statistics)
     selected_move = min(edge.move for edge in root_statistics if (edge.visits or 0) == best_visits)
@@ -376,6 +376,20 @@ def _replay_c_puct(trace: SearchTrace) -> float:
     if not math.isfinite(value) or value < 0:
         raise SemanticReplayError("c_puct must be finite and non-negative.", phase="provenance")
     return value
+
+
+def _replay_root_board(trace: SearchTrace) -> LczeroBoard:
+    if trace.root_start_fen is None or trace.root_move_history is None:
+        raise SemanticReplayError(
+            "reference traces need root history to replay history-dependent terminality.",
+            phase="root_history",
+        )
+    board = LczeroBoard(trace.root_start_fen)
+    for move_uci in trace.root_move_history:
+        board.push_uci(move_uci)
+    if board.fen() != trace.root_fen:
+        raise SemanticReplayError("root history does not reconstruct root_fen.", phase="root_history")
+    return board
 
 
 def _initialize_replay_root(root: _Node, trace: SearchTrace, event: SimulationEvent) -> None:

--- a/src/lczerolens/reference_search.py
+++ b/src/lczerolens/reference_search.py
@@ -66,6 +66,25 @@ class _Node:
     expanded: bool = False
 
 
+@dataclass(frozen=True)
+class SemanticReplayResult:
+    """Root result independently reconstructed from reference-search events."""
+
+    root_statistics: tuple[EdgeStatistics, ...]
+    root_policy: tuple[tuple[str, float], ...]
+    selected_move: str
+
+
+class SemanticReplayError(ValueError):
+    """The first semantic divergence found while replaying a search trace."""
+
+    def __init__(self, message: str, *, event_id: str | None = None, phase: str):
+        self.event_id = event_id
+        self.phase = phase
+        location = f"Event {event_id} {phase}" if event_id is not None else phase
+        super().__init__(f"{location}: {message}")
+
+
 class ReferenceMCTS:
     """Sequential PUCT search whose output is a replayable :class:`SearchTrace`.
 
@@ -93,7 +112,7 @@ class ReferenceMCTS:
 
         root = _Node(board.copy(stack=True), "node-0")
         node_count = 1
-        root_evaluation, _, _ = self._expand(root, evaluator, ValuePerspective.ROOT_PLAYER)
+        root_evaluation, root_expansion, root_evaluator = self._expand(root, evaluator, ValuePerspective.ROOT_PLAYER)
         events: list[SimulationEvent] = []
 
         for simulation in range(simulations):
@@ -158,6 +177,8 @@ class ReferenceMCTS:
                 ),
             ),
             events=tuple(events),
+            root_expansion=root_expansion,
+            root_evaluator=root_evaluator,
         )
 
     def _expand(
@@ -292,4 +313,362 @@ def replay_root_events(events: tuple[SimulationEvent, ...]) -> tuple[EdgeStatist
     return tuple(state[move] for move in sorted(state))
 
 
-__all__ = ["Evaluator", "ReferenceMCTS", "replay_root_events"]
+def replay_search_trace(trace: SearchTrace) -> SemanticReplayResult:
+    """Independently replay a deterministic-reference full trace.
+
+    Unlike :func:`replay_root_events`, this reconstructs tree state from the
+    root position and semantic event records. Recorded ``root_after`` states
+    are checked for divergence, but are never used as the replay result.
+    """
+    trace.require(SearchCapability.REPLAYABLE)
+    if trace.provenance.source != "lczerolens-reference-mcts" or trace.provenance.engine != "deterministic-reference":
+        raise SemanticReplayError(
+            "semantic replay is limited to deterministic ReferenceMCTS traces.",
+            phase="provenance",
+        )
+    events = trace.events or ()
+    if not events:
+        raise SemanticReplayError("at least one simulation event is required.", phase="events")
+    c_puct = _replay_c_puct(trace)
+    root_board = LczeroBoard(trace.root_fen)
+    first = events[0]
+    if not first.path:
+        raise SemanticReplayError(
+            "a non-terminal root simulation needs a path.", event_id=first.event_id, phase="path"
+        )
+    root_id = first.path[0].node_id
+    root = _Node(root_board, root_id)
+    _initialize_replay_root(root, trace, first)
+    nodes = {root_id: root}
+
+    for expected_simulation, event in enumerate(events):
+        if event.simulation != expected_simulation:
+            raise SemanticReplayError(
+                f"expected simulation {expected_simulation}, got {event.simulation}.",
+                event_id=event.event_id,
+                phase="sequence",
+            )
+        before = _replay_edge_stats(root, ValuePerspective.ROOT_PLAYER)
+        _check_edge_sequence(event.root_before, before, event, "root_before")
+        path = _replay_path(root, nodes, event, c_puct)
+        leaf_node = path[-1][2]
+        _replay_leaf(leaf_node, event, root.board.turn)
+        _replay_backups(path, event)
+        after = _replay_edge_stats(root, ValuePerspective.ROOT_PLAYER)
+        _check_edge_sequence(event.root_after, after, event, "root_after")
+
+    root_statistics = _replay_edge_stats(root, ValuePerspective.ROOT_PLAYER)
+    total_visits = sum(edge.visits or 0 for edge in root_statistics)
+    if total_visits <= 0:
+        raise SemanticReplayError("replayed root has no visits.", phase="result")
+    root_policy = tuple((edge.move, (edge.visits or 0) / total_visits) for edge in root_statistics)
+    best_visits = max(edge.visits or 0 for edge in root_statistics)
+    selected_move = min(edge.move for edge in root_statistics if (edge.visits or 0) == best_visits)
+    _check_replay_result(trace, root_statistics, selected_move)
+    return SemanticReplayResult(root_statistics, root_policy, selected_move)
+
+
+def _replay_c_puct(trace: SearchTrace) -> float:
+    values = [parameter.value for parameter in trace.provenance.parameters if parameter.name == "c_puct"]
+    if len(values) != 1 or isinstance(values[0], bool) or not isinstance(values[0], (int, float)):
+        raise SemanticReplayError("provenance needs one numeric c_puct parameter.", phase="provenance")
+    value = float(values[0])
+    if not math.isfinite(value) or value < 0:
+        raise SemanticReplayError("c_puct must be finite and non-negative.", phase="provenance")
+    return value
+
+
+def _initialize_replay_root(root: _Node, trace: SearchTrace, event: SimulationEvent) -> None:
+    initial = event.root_before or ()
+    legal = {move.uci(): move for move in root.board.legal_moves}
+    expansion = trace.root_expansion
+    evaluator = trace.root_evaluator
+    if expansion is None or evaluator is None or expansion.node_id != root.node_id:
+        raise SemanticReplayError(
+            "reference trace needs matching root expansion and evaluator evidence.", phase="root_expansion"
+        )
+    expanded = {edge.move: edge for edge in expansion.edges}
+    logits = dict(evaluator.legal_policy_logits or ())
+    if expanded.keys() != legal.keys() or logits.keys() != legal.keys():
+        raise SemanticReplayError(
+            "expanded root edges and evaluator logits must match the legal moves.", phase="root_expansion"
+        )
+    priors = _priors_from_logits(logits, evaluator.dtype)
+    if {edge.move for edge in initial} != legal.keys():
+        raise SemanticReplayError(
+            "initial root edges do not match the legal moves.", event_id=event.event_id, phase="root_before"
+        )
+    for move in sorted(legal):
+        edge = expanded[move]
+        if (
+            edge.perspective is not ValuePerspective.ROOT_PLAYER
+            or edge.prior is None
+            or (edge.visits, edge.total_value, edge.mean_value) != (0, 0.0, 0.0)
+            or not _close(edge.prior, priors[move])
+        ):
+            raise SemanticReplayError(
+                f"root edge {move} does not match the evaluator-derived initial state.", phase="root_expansion"
+            )
+        root.edges[move] = _Edge(legal[move], priors[move])
+    for edge in initial:
+        if edge.perspective is not ValuePerspective.ROOT_PLAYER:
+            raise SemanticReplayError(
+                f"root edge {edge.move} has perspective {edge.perspective.value}.",
+                event_id=event.event_id,
+                phase="root_before",
+            )
+        if (
+            edge.prior is None
+            or (edge.visits, edge.total_value, edge.mean_value) != (0, 0.0, 0.0)
+            or not _close(edge.prior, root.edges[edge.move].prior)
+        ):
+            raise SemanticReplayError(
+                f"root edge {edge.move} is not an unvisited initialized edge.",
+                event_id=event.event_id,
+                phase="root_before",
+            )
+    root.expanded = True
+
+
+def _replay_path(
+    root: _Node, nodes: dict[str, _Node], event: SimulationEvent, c_puct: float
+) -> list[tuple[_Node, _Edge, _Node]]:
+    node = root
+    replayed: list[tuple[_Node, _Edge, _Node]] = []
+    for depth, recorded in enumerate(event.path):
+        if not node.expanded or not node.edges:
+            raise SemanticReplayError(
+                f"path continues beyond unexpanded node {node.node_id} at depth {depth}.",
+                event_id=event.event_id,
+                phase="path",
+            )
+        expected_edge = _replay_select(node, c_puct)
+        if recorded.node_id != node.node_id or recorded.move != expected_edge.move.uci():
+            raise SemanticReplayError(
+                f"depth {depth} expected {node.node_id}:{expected_edge.move.uci()}, "
+                f"got {recorded.node_id}:{recorded.move}.",
+                event_id=event.event_id,
+                phase="path",
+            )
+        if expected_edge.child is None:
+            if recorded.child_id in nodes:
+                raise SemanticReplayError(
+                    f"new child ID {recorded.child_id!r} is already in use.",
+                    event_id=event.event_id,
+                    phase="path",
+                )
+            child_board = node.board.copy(stack=True)
+            child_board.push(expected_edge.move)
+            expected_edge.child = _Node(child_board, recorded.child_id)
+            nodes[recorded.child_id] = expected_edge.child
+        elif expected_edge.child.node_id != recorded.child_id:
+            raise SemanticReplayError(
+                f"edge {recorded.move} points to {expected_edge.child.node_id!r}, not {recorded.child_id!r}.",
+                event_id=event.event_id,
+                phase="path",
+            )
+        child = expected_edge.child
+        replayed.append((node, expected_edge, child))
+        node = child
+        if not node.expanded:
+            if depth != len(event.path) - 1:
+                raise SemanticReplayError(
+                    f"path continues after first unexpanded node {node.node_id}.",
+                    event_id=event.event_id,
+                    phase="path",
+                )
+            break
+    if not replayed:
+        raise SemanticReplayError("simulation path is empty.", event_id=event.event_id, phase="path")
+    if node.expanded:
+        raise SemanticReplayError(
+            f"path ends early at already expanded node {node.node_id}.",
+            event_id=event.event_id,
+            phase="path",
+        )
+    return replayed
+
+
+def _replay_select(node: _Node, c_puct: float) -> _Edge:
+    scale = math.sqrt(sum(edge.visits for edge in node.edges.values()))
+    scores = {
+        move: edge.mean_value + c_puct * edge.prior * scale / (1 + edge.visits) for move, edge in node.edges.items()
+    }
+    best = max(scores.values())
+    return node.edges[min(move for move, score in scores.items() if score == best)]
+
+
+def _replay_leaf(node: _Node, event: SimulationEvent, root_turn: chess.Color) -> None:
+    if event.leaf.node_id != node.node_id:
+        raise SemanticReplayError(
+            f"path ends at {node.node_id!r}, but leaf is {event.leaf.node_id!r}.",
+            event_id=event.event_id,
+            phase="leaf",
+        )
+    terminal = node.board.is_game_over()
+    if event.leaf.terminal is not terminal:
+        raise SemanticReplayError(
+            "terminal flag disagrees with the replayed board.", event_id=event.event_id, phase="leaf"
+        )
+    perspective = ValuePerspective.ROOT_PLAYER if node.board.turn == root_turn else ValuePerspective.SIDE_TO_MOVE
+    if event.leaf.evaluation.perspective is not perspective:
+        raise SemanticReplayError(
+            f"expected {perspective.value} evaluation perspective.", event_id=event.event_id, phase="leaf"
+        )
+    if terminal:
+        if event.expansion is not None or event.leaf.evaluator is not None:
+            raise SemanticReplayError(
+                "terminal leaves cannot have an expansion or evaluator call.", event_id=event.event_id, phase="leaf"
+            )
+        outcome = node.board.outcome()
+        expected = (
+            0.0 if outcome is None or outcome.winner is None else 1.0 if outcome.winner == node.board.turn else -1.0
+        )
+        if not _close(event.leaf.evaluation.value, expected):
+            raise SemanticReplayError(f"terminal value should be {expected}.", event_id=event.event_id, phase="leaf")
+        return
+    if event.expansion is None or event.leaf.evaluator is None:
+        raise SemanticReplayError(
+            "non-terminal first visits need expansion and evaluator evidence.",
+            event_id=event.event_id,
+            phase="expansion",
+        )
+    _replay_expansion(node, event, perspective)
+
+
+def _replay_expansion(node: _Node, event: SimulationEvent, perspective: ValuePerspective) -> None:
+    expansion = event.expansion
+    evaluator = event.leaf.evaluator
+    assert expansion is not None and evaluator is not None
+    if expansion.node_id != node.node_id:
+        raise SemanticReplayError(
+            "expansion node does not match the leaf.", event_id=event.event_id, phase="expansion"
+        )
+    legal = {move.uci(): move for move in node.board.legal_moves}
+    edges = {edge.move: edge for edge in expansion.edges}
+    logits = dict(evaluator.legal_policy_logits or ())
+    if edges.keys() != legal.keys() or logits.keys() != legal.keys():
+        raise SemanticReplayError(
+            "expanded edges and evaluator logits must match the legal moves.",
+            event_id=event.event_id,
+            phase="expansion",
+        )
+    priors = _priors_from_logits(logits, evaluator.dtype)
+    ordered = sorted(legal)
+    for move in ordered:
+        edge = edges[move]
+        if edge.perspective is not perspective or edge.prior is None:
+            raise SemanticReplayError(
+                f"edge {move} has the wrong perspective or no prior.",
+                event_id=event.event_id,
+                phase="expansion",
+            )
+        if (edge.visits, edge.total_value, edge.mean_value) != (0, 0.0, 0.0) or not _close(edge.prior, priors[move]):
+            raise SemanticReplayError(
+                f"edge {move} does not match the evaluator-derived initial state.",
+                event_id=event.event_id,
+                phase="expansion",
+            )
+        node.edges[move] = _Edge(legal[move], priors[move])
+    node.expanded = True
+
+
+def _priors_from_logits(logits: dict[str, float], dtype_name: str) -> dict[str, float]:
+    ordered = sorted(logits)
+    dtype = getattr(torch, dtype_name, None)
+    if not isinstance(dtype, torch.dtype) or not dtype.is_floating_point:
+        raise SemanticReplayError(f"unsupported evaluator dtype {dtype_name!r}.", phase="expansion")
+    probabilities = torch.tensor([logits[move] for move in ordered], dtype=dtype).softmax(0).tolist()
+    return dict(zip(ordered, probabilities))
+
+
+def _replay_backups(path: list[tuple[_Node, _Edge, _Node]], event: SimulationEvent) -> None:
+    if event.leaf.evaluation.value is None:
+        raise SemanticReplayError("scalar leaf value is required.", event_id=event.event_id, phase="backup")
+    if len(event.backups) != len(path):
+        raise SemanticReplayError(
+            f"expected {len(path)} backups, got {len(event.backups)}.",
+            event_id=event.event_id,
+            phase="backup",
+        )
+    value = event.leaf.evaluation.value
+    for index, ((parent, edge, _), recorded) in enumerate(zip(reversed(path), event.backups)):
+        value = -value
+        perspective = ValuePerspective.ROOT_PLAYER if parent is path[0][0] else ValuePerspective.SIDE_TO_MOVE
+        before = ReferenceMCTS._edge_stat(edge, perspective)
+        if (
+            recorded.node_id != parent.node_id
+            or not _close(recorded.signed_value, value)
+            or not _same_edge(recorded.before, before)
+        ):
+            raise SemanticReplayError(
+                f"backup {index} does not match reconstructed node, value, or pre-state.",
+                event_id=event.event_id,
+                phase="backup",
+            )
+        edge.visits += 1
+        edge.total_value += value
+        after = ReferenceMCTS._edge_stat(edge, perspective)
+        if not _same_edge(recorded.after, after):
+            raise SemanticReplayError(
+                f"backup {index} post-state diverges from the reconstructed update.",
+                event_id=event.event_id,
+                phase="backup",
+            )
+
+
+def _replay_edge_stats(node: _Node, perspective: ValuePerspective) -> tuple[EdgeStatistics, ...]:
+    return tuple(ReferenceMCTS._edge_stat(node.edges[move], perspective) for move in sorted(node.edges))
+
+
+def _check_edge_sequence(
+    recorded: tuple[EdgeStatistics, ...] | None,
+    replayed: tuple[EdgeStatistics, ...],
+    event: SimulationEvent,
+    phase: str,
+) -> None:
+    if (
+        recorded is None
+        or len(recorded) != len(replayed)
+        or any(not _same_edge(left, right) for left, right in zip(recorded, replayed))
+    ):
+        raise SemanticReplayError("recorded root state diverges from replay.", event_id=event.event_id, phase=phase)
+
+
+def _check_replay_result(trace: SearchTrace, root_statistics: tuple[EdgeStatistics, ...], selected_move: str) -> None:
+    final = trace.snapshots[-1]
+    actions = tuple(action.statistics for action in final.actions or ())
+    if len(actions) != len(root_statistics) or any(
+        not _same_edge(left, right) for left, right in zip(actions, root_statistics)
+    ):
+        raise SemanticReplayError("final root action statistics diverge from replay.", phase="result")
+    if final.selection is None or final.selection.move != selected_move:
+        raise SemanticReplayError("selected move diverges from replay.", phase="result")
+
+
+def _same_edge(left: EdgeStatistics, right: EdgeStatistics) -> bool:
+    return (
+        left.move == right.move
+        and left.perspective is right.perspective
+        and _close(left.prior, right.prior)
+        and left.visits == right.visits
+        and _close(left.total_value, right.total_value)
+        and _close(left.mean_value, right.mean_value)
+        and _close(left.exploration, right.exploration)
+    )
+
+
+def _close(left: float | None, right: float | None) -> bool:
+    if left is None or right is None:
+        return left is right
+    return math.isclose(left, right, rel_tol=1e-6, abs_tol=1e-6)
+
+
+__all__ = [
+    "Evaluator",
+    "ReferenceMCTS",
+    "SemanticReplayError",
+    "SemanticReplayResult",
+    "replay_root_events",
+    "replay_search_trace",
+]

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -435,6 +435,8 @@ class SearchTrace:
     events: tuple[SimulationEvent, ...] | None = None
     root_expansion: NodeExpansion | None = None
     root_evaluator: EvaluatorCall | None = None
+    root_start_fen: str | None = None
+    root_move_history: tuple[str, ...] | None = None
     schema_version: int = field(default=1, init=False)
 
     def __post_init__(self) -> None:
@@ -447,6 +449,20 @@ class SearchTrace:
         fen_player = ChessPlayer.WHITE if board.turn is chess.WHITE else ChessPlayer.BLACK
         if self.root_player is not fen_player:
             raise ValueError("root_player must match the side to move in root_fen.")
+        if (self.root_start_fen is None) != (self.root_move_history is None):
+            raise ValueError("root history requires both a starting FEN and move sequence.")
+        if self.root_start_fen is not None and self.root_move_history is not None:
+            try:
+                history_board = chess.Board(self.root_start_fen)
+                for move_uci in self.root_move_history:
+                    move = chess.Move.from_uci(move_uci)
+                    if move not in history_board.legal_moves:
+                        raise ValueError("Root history moves must be legal from root_start_fen.")
+                    history_board.push(move)
+            except ValueError as error:
+                raise ValueError("root history must be a legal sequence from root_start_fen.") from error
+            if history_board.fen() != self.root_fen:
+                raise ValueError("root history must reconstruct root_fen.")
         legal_moves = {move.uci() for move in board.legal_moves}
         for snapshot in self.snapshots:
             if snapshot.selection is not None and snapshot.selection.move not in legal_moves:

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -433,6 +433,8 @@ class SearchTrace:
     provenance: SearchProvenance
     snapshots: tuple[RootSnapshot, ...]
     events: tuple[SimulationEvent, ...] | None = None
+    root_expansion: NodeExpansion | None = None
+    root_evaluator: EvaluatorCall | None = None
     schema_version: int = field(default=1, init=False)
 
     def __post_init__(self) -> None:

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -464,6 +464,8 @@ class SearchTrace:
             if history_board.fen() != self.root_fen:
                 raise ValueError("root history must reconstruct root_fen.")
         legal_moves = {move.uci() for move in board.legal_moves}
+        if self.root_expansion is not None and any(edge.move not in legal_moves for edge in self.root_expansion.edges):
+            raise ValueError("Every root expansion edge must be legal in root_fen.")
         for snapshot in self.snapshots:
             if snapshot.selection is not None and snapshot.selection.move not in legal_moves:
                 raise ValueError("The selected root move must be legal in root_fen.")

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -21,6 +21,7 @@ from lczerolens.search_trace import (
     SearchCapability,
     SimulationEvent,
     ValuePerspective,
+    Wdl,
 )
 
 
@@ -153,6 +154,256 @@ def test_semantic_replay_rejects_recorded_post_state_instead_of_returning_it():
 
     with pytest.raises(SemanticReplayError, match=r"Event simulation-0 backup: backup 0"):
         replay_search_trace(invalid)
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    (
+        (lambda trace: replace(trace, provenance=replace(trace.provenance, source="other")), "provenance: semantic"),
+        (
+            lambda trace: replace(
+                trace, provenance=replace(trace.provenance, parameters=trace.provenance.parameters[1:])
+            ),
+            "provenance: provenance needs",
+        ),
+        (
+            lambda trace: replace(
+                trace,
+                provenance=replace(
+                    trace.provenance,
+                    parameters=(replace(trace.provenance.parameters[0], value=-1.0), *trace.provenance.parameters[1:]),
+                ),
+            ),
+            "provenance: c_puct",
+        ),
+        (lambda trace: replace(trace, events=()), "events: at least one"),
+        (
+            lambda trace: replace(trace, events=(replace(trace.events[0], path=()),)),
+            "Event simulation-0 path: a non-terminal root simulation needs a path",
+        ),
+        (
+            lambda trace: replace(trace, events=(replace(trace.events[0], simulation=1),)),
+            "Event simulation-0 sequence: expected simulation 0",
+        ),
+        (lambda trace: replace(trace, root_expansion=None), "root_expansion: reference trace needs"),
+        (
+            lambda trace: replace(
+                trace,
+                root_evaluator=replace(
+                    trace.root_evaluator,
+                    legal_policy_logits=trace.root_evaluator.legal_policy_logits[:-1],
+                ),
+            ),
+            "root_expansion: expanded root edges",
+        ),
+        (
+            lambda trace: replace(
+                trace,
+                root_expansion=replace(
+                    trace.root_expansion,
+                    edges=(
+                        replace(trace.root_expansion.edges[0], perspective=ValuePerspective.SIDE_TO_MOVE),
+                        *trace.root_expansion.edges[1:],
+                    ),
+                ),
+            ),
+            "root_expansion: root edge",
+        ),
+        (
+            lambda trace: replace(
+                trace,
+                root_evaluator=replace(trace.root_evaluator, dtype="int64"),
+            ),
+            "expansion: unsupported evaluator dtype",
+        ),
+    ),
+)
+def test_semantic_replay_rejects_invalid_trace_level_evidence(mutation, message):
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+
+    with pytest.raises(SemanticReplayError, match=message):
+        replay_search_trace(mutation(trace))
+
+
+@pytest.mark.parametrize(
+    ("mutate_event", "message"),
+    (
+        (
+            lambda event, trace: replace(event, leaf=replace(event.leaf, node_id="wrong-node")),
+            "Event simulation-0 leaf: path ends",
+        ),
+        (
+            lambda event, trace: replace(event, leaf=replace(event.leaf, terminal=True)),
+            "Event simulation-0 leaf: terminal flag",
+        ),
+        (
+            lambda event, trace: replace(event, expansion=None),
+            "Event simulation-0 expansion: non-terminal first visits",
+        ),
+        (
+            lambda event, trace: replace(event, expansion=replace(event.expansion, node_id="wrong-node")),
+            "Event simulation-0 expansion: expansion node",
+        ),
+        (
+            lambda event, trace: replace(
+                event,
+                leaf=replace(
+                    event.leaf,
+                    evaluator=replace(
+                        event.leaf.evaluator,
+                        legal_policy_logits=event.leaf.evaluator.legal_policy_logits[:-1],
+                    ),
+                ),
+            ),
+            "Event simulation-0 expansion: expanded edges",
+        ),
+        (
+            lambda event, trace: replace(
+                event,
+                expansion=replace(
+                    event.expansion,
+                    edges=(
+                        replace(event.expansion.edges[0], perspective=ValuePerspective.ROOT_PLAYER),
+                        *event.expansion.edges[1:],
+                    ),
+                ),
+            ),
+            "Event simulation-0 expansion: edge",
+        ),
+        (
+            lambda event, trace: replace(event, backups=(*event.backups, event.backups[0])),
+            "Event simulation-0 backup: expected 1 backups, got 2",
+        ),
+    ),
+)
+def test_semantic_replay_rejects_invalid_event_evidence(mutate_event, message):
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    invalid_event = mutate_event(trace.events[0], trace)
+    invalid = replace(trace, events=(invalid_event,))
+
+    with pytest.raises(SemanticReplayError, match=message):
+        replay_search_trace(invalid)
+
+
+def test_semantic_replay_rejects_terminal_evaluator_and_value_divergences():
+    board = LczeroBoard("8/8/8/8/8/8/4Q3/K1k5 w - - 0 1")
+    trace = ReferenceMCTS(c_puct=0.0).search(board, FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    with_evaluator = replace(event, leaf=replace(event.leaf, evaluator=trace.root_evaluator))
+    wrong_value = replace(
+        event,
+        leaf=replace(event.leaf, evaluation=replace(event.leaf.evaluation, value=0.5)),
+    )
+
+    with pytest.raises(SemanticReplayError, match="terminal leaves cannot have"):
+        replay_search_trace(replace(trace, events=(with_evaluator,)))
+    with pytest.raises(SemanticReplayError, match="terminal value should be"):
+        replay_search_trace(replace(trace, events=(wrong_value,)))
+
+
+def test_semantic_replay_rejects_reused_or_changed_child_identity():
+    trace = ReferenceMCTS(c_puct=0.0).search(LczeroBoard(), FixedEvaluator(-0.4), simulations=2)
+    first, second = trace.events
+    reused_root = replace(first.path[0], child_id=first.path[0].node_id)
+    changed_child = replace(second.path[0], child_id="other-child")
+
+    with pytest.raises(SemanticReplayError, match="new child ID .* already in use"):
+        replay_search_trace(replace(trace, events=(replace(first, path=(reused_root,)), second)))
+    with pytest.raises(SemanticReplayError, match="edge .* points to"):
+        replay_search_trace(replace(trace, events=(first, replace(second, path=(changed_child, *second.path[1:])))))
+
+
+def test_semantic_replay_rejects_wrong_selected_move():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    final = trace.snapshots[-1]
+    other_move = next(
+        action.statistics.move for action in final.actions if action.statistics.move != final.selection.move
+    )
+    invalid_selection = replace(final.selection, move=other_move)
+
+    with pytest.raises(SemanticReplayError, match="result: selected move diverges"):
+        replay_search_trace(replace(trace, snapshots=(replace(final, selection=invalid_selection),)))
+
+
+@pytest.mark.parametrize(
+    ("root_before", "message"),
+    (
+        (lambda edges: edges[:-1], "initial root edges do not match"),
+        (
+            lambda edges: (
+                replace(edges[0], perspective=ValuePerspective.SIDE_TO_MOVE),
+                *edges[1:],
+            ),
+            "root edge .* has perspective",
+        ),
+        (
+            lambda edges: (replace(edges[0], visits=1, total_value=0.0, mean_value=0.0), *edges[1:]),
+            "root edge .* is not an unvisited",
+        ),
+    ),
+)
+def test_semantic_replay_rejects_corrupt_initial_root_state(root_before, message):
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    # Model corruption that can arrive from untrusted persisted trace data.
+    object.__setattr__(event, "root_before", root_before(event.root_before))
+
+    with pytest.raises(SemanticReplayError, match=message):
+        replay_search_trace(trace)
+
+
+def test_semantic_replay_rejects_path_past_first_unexpanded_node():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    extra = replace(event.path[0], node_id=event.path[0].child_id, child_id="extra-child")
+
+    with pytest.raises(SemanticReplayError, match="path continues after first unexpanded node"):
+        replay_search_trace(replace(trace, events=(replace(event, path=(*event.path, extra)),)))
+
+
+def test_semantic_replay_requires_scalar_leaf_value_for_backup():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    perspective = event.leaf.evaluation.perspective
+    wdl_only = PositionEvaluation(perspective, wdl=Wdl(0.5, 0.25, 0.25, perspective))
+    invalid_leaf = replace(event.leaf, evaluation=wdl_only)
+
+    with pytest.raises(SemanticReplayError, match="backup: scalar leaf value is required"):
+        replay_search_trace(replace(trace, events=(replace(event, leaf=invalid_leaf),)))
+
+
+def test_semantic_replay_rejects_backup_post_state_divergence():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    backup = event.backups[0]
+    altered_after = replace(backup.after, exploration=0.1)
+    altered_backup = replace(backup, after=altered_after)
+    altered_root_after = tuple(altered_after if edge.move == altered_after.move else edge for edge in event.root_after)
+    altered_actions = tuple(
+        replace(action, statistics=altered_after) if action.statistics.move == altered_after.move else action
+        for action in trace.snapshots[-1].actions
+    )
+    invalid = replace(
+        trace,
+        events=(replace(event, backups=(altered_backup,), root_after=altered_root_after),),
+        snapshots=(replace(trace.snapshots[-1], actions=altered_actions),),
+    )
+
+    with pytest.raises(SemanticReplayError, match="backup 0 post-state diverges"):
+        replay_search_trace(invalid)
+
+
+def test_semantic_replay_rejects_root_and_final_action_state_divergence():
+    root_trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=2)
+    object.__setattr__(root_trace.events[1], "root_before", None)
+    with pytest.raises(SemanticReplayError, match="root_before: recorded root state diverges"):
+        replay_search_trace(root_trace)
+
+    result_trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    final = result_trace.snapshots[-1]
+    object.__setattr__(final, "actions", final.actions[:-1])
+    with pytest.raises(SemanticReplayError, match="result: final root action statistics diverge"):
+        replay_search_trace(result_trace)
 
 
 def test_reference_search_accepts_the_canonical_singleton_evaluator_batch():

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -1,11 +1,18 @@
 """Hermetic checks for the deterministic, replayable MCTS reference core."""
 
+from dataclasses import replace
+
 import pytest
 import torch
 from tensordict import TensorDict
 
 from lczerolens import LczeroBoard
-from lczerolens.reference_search import ReferenceMCTS, replay_root_events
+from lczerolens.reference_search import (
+    ReferenceMCTS,
+    SemanticReplayError,
+    replay_root_events,
+    replay_search_trace,
+)
 from lczerolens.search_trace import (
     BackupUpdate,
     EdgeStatistics,
@@ -68,6 +75,84 @@ def test_reference_search_revisits_a_child_and_alternates_backup_signs():
 
     assert len(trace.events[1].path) == 2
     assert [backup.signed_value for backup in trace.events[1].backups] == pytest.approx((0.4, -0.4))
+
+
+@pytest.mark.parametrize(
+    ("fen", "simulations", "c_puct"),
+    (
+        ("8/8/8/8/8/8/4Q3/K1k5 w - - 0 1", 1, 0.0),  # terminal leaf
+        ("7k/8/8/8/8/8/6r1/7K w - - 0 1", 3, 1.0),  # forced root move
+        (None, 2, 0.0),  # repeated visit
+        (None, 32, 1.5),  # competitive root
+    ),
+)
+def test_semantic_replay_reconstructs_representative_search_results(fen, simulations, c_puct):
+    board = LczeroBoard(fen) if fen is not None else LczeroBoard()
+    trace = ReferenceMCTS(c_puct=c_puct).search(board, FixedEvaluator(), simulations)
+
+    result = replay_search_trace(trace)
+
+    assert result.root_statistics == tuple(action.statistics for action in trace.snapshots[-1].actions)
+    assert sum(probability for _, probability in result.root_policy) == pytest.approx(1.0)
+    assert result.selected_move == trace.snapshots[-1].selection.move
+
+
+def test_semantic_replay_reports_first_path_divergence():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=2)
+    event = trace.events[0]
+    wrong_move = next(edge.move for edge in event.root_before if edge.move != event.path[0].move)
+    wrong_step = replace(event.path[0], move=wrong_move)
+    invalid = replace(trace, events=(replace(event, path=(wrong_step,)), *trace.events[1:]))
+
+    with pytest.raises(SemanticReplayError, match=r"Event simulation-0 path: depth 0 expected"):
+        replay_search_trace(invalid)
+
+
+def test_semantic_replay_reports_first_expansion_divergence():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    evaluator = event.leaf.evaluator
+    altered_logits = ((evaluator.legal_policy_logits[0][0], 100.0), *evaluator.legal_policy_logits[1:])
+    invalid_leaf = replace(event.leaf, evaluator=replace(evaluator, legal_policy_logits=altered_logits))
+    invalid = replace(trace, events=(replace(event, leaf=invalid_leaf),))
+
+    with pytest.raises(SemanticReplayError, match=r"Event simulation-0 expansion: edge"):
+        replay_search_trace(invalid)
+
+
+def test_semantic_replay_reports_first_perspective_divergence():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    wrong_evaluation = replace(event.leaf.evaluation, perspective=ValuePerspective.ROOT_PLAYER)
+    invalid = replace(trace, events=(replace(event, leaf=replace(event.leaf, evaluation=wrong_evaluation)),))
+
+    with pytest.raises(SemanticReplayError, match=r"Event simulation-0 leaf: expected side_to_move"):
+        replay_search_trace(invalid)
+
+
+def test_semantic_replay_rejects_recorded_post_state_instead_of_returning_it():
+    trace = ReferenceMCTS(c_puct=1.0).search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    backup = event.backups[-1]
+    altered_after = replace(
+        backup.after,
+        total_value=-backup.after.total_value,
+        mean_value=-backup.after.mean_value,
+    )
+    altered_backup = replace(backup, signed_value=-backup.signed_value, after=altered_after)
+    altered_root_after = tuple(altered_after if edge.move == altered_after.move else edge for edge in event.root_after)
+    altered_actions = tuple(
+        replace(action, statistics=altered_after) if action.statistics.move == altered_after.move else action
+        for action in trace.snapshots[-1].actions
+    )
+    invalid = replace(
+        trace,
+        events=(replace(event, backups=(altered_backup,), root_after=altered_root_after),),
+        snapshots=(replace(trace.snapshots[-1], actions=altered_actions),),
+    )
+
+    with pytest.raises(SemanticReplayError, match=r"Event simulation-0 backup: backup 0"):
+        replay_search_trace(invalid)
 
 
 def test_reference_search_accepts_the_canonical_singleton_evaluator_batch():

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -10,6 +10,8 @@ from lczerolens import LczeroBoard
 from lczerolens.reference_search import (
     ReferenceMCTS,
     SemanticReplayError,
+    _Node,
+    _replay_path,
     replay_root_events,
     replay_search_trace,
 )
@@ -96,6 +98,56 @@ def test_semantic_replay_reconstructs_representative_search_results(fen, simulat
     assert result.root_statistics == tuple(action.statistics for action in trace.snapshots[-1].actions)
     assert sum(probability for _, probability in result.root_policy) == pytest.approx(1.0)
     assert result.selected_move == trace.snapshots[-1].selection.move
+
+
+def test_semantic_replay_preserves_root_history_for_fivefold_repetition():
+    board = LczeroBoard("8/8/6r1/8/6R1/8/K6k/8 b - - 0 1")
+    cycle = ("h2h3", "a2a1", "h3h2", "a1a2")
+    for _ in range(3):
+        for move in cycle:
+            board.push_uci(move)
+    for move in cycle[:3]:
+        board.push_uci(move)
+
+    trace = ReferenceMCTS(c_puct=0.0).search(board, FixedEvaluator(), simulations=1)
+    result = replay_search_trace(trace)
+
+    assert trace.root_start_fen == "8/8/6r1/8/6R1/8/K6k/8 b - - 0 1"
+    assert trace.root_move_history == tuple(board_move.uci() for board_move in board.move_stack)
+    assert trace.events[0].leaf.terminal
+    assert result.selected_move == trace.snapshots[-1].selection.move
+
+
+def test_semantic_replay_requires_complete_and_consistent_root_history():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=1)
+
+    with pytest.raises(ValueError, match="both a starting FEN and move sequence"):
+        replace(trace, root_start_fen=None)
+    with pytest.raises(ValueError, match="root history must reconstruct root_fen"):
+        replace(trace, root_move_history=("e2e4",))
+    with pytest.raises(ValueError, match="root history must be a legal sequence"):
+        replace(trace, root_move_history=("e2e5",))
+
+    legacy = replace(trace, root_start_fen=None, root_move_history=None)
+    with pytest.raises(SemanticReplayError, match="root_history: reference traces need root history"):
+        replay_search_trace(legacy)
+
+    object.__setattr__(trace, "root_move_history", ("e2e4",))
+    with pytest.raises(SemanticReplayError, match="root_history: root history does not reconstruct"):
+        replay_search_trace(trace)
+
+
+def test_semantic_replay_path_rejects_unreachable_internal_states():
+    trace = ReferenceMCTS(c_puct=0.0).search(LczeroBoard(), FixedEvaluator(-0.4), simulations=2)
+    first, second = trace.events
+    unexpanded_root = _Node(LczeroBoard(), "node-0")
+
+    with pytest.raises(SemanticReplayError, match="path continues beyond unexpanded"):
+        _replay_path(unexpanded_root, {"node-0": unexpanded_root}, first, c_puct=0.0)
+    with pytest.raises(SemanticReplayError, match="simulation path is empty"):
+        _replay_path(unexpanded_root, {"node-0": unexpanded_root}, replace(first, path=()), c_puct=0.0)
+    with pytest.raises(SemanticReplayError, match="path ends early at already expanded"):
+        replay_search_trace(replace(trace, events=(first, replace(second, path=second.path[:1]))))
 
 
 def test_semantic_replay_reports_first_path_divergence():

--- a/tests/unit/test_search_trace.py
+++ b/tests/unit/test_search_trace.py
@@ -572,6 +572,18 @@ def test_search_trace_validation_errors():
                 }
             )
         )
+    with pytest.raises(ValueError, match="Every root expansion edge"):
+        SearchTrace(
+            **(
+                trace_args
+                | {
+                    "root_expansion": NodeExpansion(
+                        "root",
+                        (EdgeStatistics("e2e5", ValuePerspective.ROOT_PLAYER, prior=1.0),),
+                    ),
+                }
+            )
+        )
     for variation, message in (
         (("e2e4", "not-a-move"), "valid UCI"),
         (("e2e4", "e2e4"), "legal in sequence"),


### PR DESCRIPTION
## Summary

- retain root expansion and evaluator evidence on deterministic reference-search traces
- add independent full-trace semantic replay that rebuilds PUCT paths, expansions, terminal values, perspective-aware backups, root visit policy, and selected move
- report the first divergence by event and replay phase while keeping the existing root-transition validator available
- document the reference-only capability boundary and export the new replay API

## Validation

- `uv run --group dev pre-commit run --all-files`
- `just tests` (252 passed, 13 deselected; 88.61% coverage)

closes #155