### PR TITLE
Add ordered retained-event replay plans

### DIFF
--- a/src/lczerolens/__init__.py
+++ b/src/lczerolens/__init__.py
@@ -31,8 +31,13 @@ from .model import LczeroModel
 from .move_evidence import MoveDelta, VariationEvidence, analyze_move_delta, analyze_variation
 from .reference_search import (
     ReferenceMCTS,
+    RetainedEventReplayCosts,
+    RetainedEventReplayPlan,
+    RetainedEventReplayResult,
     SemanticReplayError,
     SemanticReplayResult,
+    plan_retained_events,
+    replay_retained_events,
     replay_root_events,
     replay_search_trace,
 )
@@ -62,6 +67,9 @@ __all__ = [
     "MoveDelta",
     "PositionAttribute",
     "ReferenceMCTS",
+    "RetainedEventReplayCosts",
+    "RetainedEventReplayPlan",
+    "RetainedEventReplayResult",
     "SemanticReplayError",
     "SemanticReplayResult",
     "SearchBehaviorComparison",
@@ -73,9 +81,11 @@ __all__ = [
     "compare_search_decision",
     "compare_search_events",
     "evaluator_behavior",
+    "plan_retained_events",
     "relocate_piece_counterfactual",
     "remove_piece_counterfactual",
     "replay_root_events",
+    "replay_retained_events",
     "replay_search_trace",
     "sibling_counterfactual",
 ]

--- a/src/lczerolens/reference_search.py
+++ b/src/lczerolens/reference_search.py
@@ -409,20 +409,15 @@ def replay_retained_events(trace: SearchTrace, event_ids: tuple[str, ...] | None
     )
     result = RetainedEventReplayResult(root_statistics, root_policy, selected_move, plan, costs)
     if len(plan.events) == len(events):
-        semantic = replay_search_trace(trace)
+        final = trace.snapshots[-1]
+        final_statistics = tuple(action.statistics for action in final.actions or ())
         if (
-            len(result.root_statistics) != len(semantic.root_statistics)
-            or any(
-                not _same_edge(left, right) for left, right in zip(result.root_statistics, semantic.root_statistics)
-            )
-            or len(result.root_policy) != len(semantic.root_policy)
-            or any(
-                left[0] != right[0] or not _close(left[1], right[1])
-                for left, right in zip(result.root_policy, semantic.root_policy)
-            )
-            or result.selected_move != semantic.selected_move
+            len(result.root_statistics) != len(final_statistics)
+            or any(not _same_edge(left, right) for left, right in zip(result.root_statistics, final_statistics))
+            or final.selection is None
+            or result.selected_move != final.selection.move
         ):
-            raise SemanticReplayError("full retained-event replay diverges from semantic replay.", phase="result")
+            raise ValueError("Full retained-event replay diverges from the recorded root result.")
     return result
 
 

--- a/src/lczerolens/reference_search.py
+++ b/src/lczerolens/reference_search.py
@@ -85,6 +85,41 @@ class SemanticReplayError(ValueError):
         super().__init__(f"{location}: {message}")
 
 
+@dataclass(frozen=True)
+class RetainedEventReplayPlan:
+    """An ordered, explicit selection of events from one replayable trace.
+
+    ``events`` always follows the trace's original order, irrespective of the
+    order in which callers supplied event IDs.  Events outside this plan make
+    no contribution to the replayed result.
+    """
+
+    retained_event_ids: tuple[str, ...]
+    omitted_event_ids: tuple[str, ...]
+    events: tuple[SimulationEvent, ...]
+
+
+@dataclass(frozen=True)
+class RetainedEventReplayCosts:
+    """Observed work represented by a retained-event replay plan."""
+
+    simulations: int
+    evaluator_calls: int
+    expansions: int
+    backup_updates: int
+
+
+@dataclass(frozen=True)
+class RetainedEventReplayResult:
+    """Root decision evidence reconstructed from a retained-event plan."""
+
+    root_statistics: tuple[EdgeStatistics, ...]
+    root_policy: tuple[tuple[str, float], ...]
+    selected_move: str
+    plan: RetainedEventReplayPlan
+    costs: RetainedEventReplayCosts
+
+
 class ReferenceMCTS:
     """Sequential PUCT search whose output is a replayable :class:`SearchTrace`.
 
@@ -313,6 +348,135 @@ def replay_root_events(events: tuple[SimulationEvent, ...]) -> tuple[EdgeStatist
             raise ValueError(f"Event {event.event_id} has no matching root backup.")
         state = after
     return tuple(state[move] for move in sorted(state))
+
+
+def plan_retained_events(trace: SearchTrace, event_ids: tuple[str, ...] | None = None) -> RetainedEventReplayPlan:
+    """Resolve an explicit retained-event selection in original trace order.
+
+    An empty tuple is an intentional empty selection; ``None`` selects every
+    event.  The plan does not add structural events: each selected event must
+    carry the root transition needed to account for its own backup.
+    """
+    trace.require(SearchCapability.REPLAYABLE)
+    events = trace.events or ()
+    known = {event.event_id: event for event in events}
+    if len(known) != len(events):
+        raise ValueError("Replayable traces require unique event IDs.")
+    requested = tuple(known) if event_ids is None else tuple(event_ids)
+    if len(requested) != len(set(requested)):
+        raise ValueError("Retained event IDs must be unique.")
+    unknown = sorted(set(requested) - known.keys())
+    if unknown:
+        raise ValueError(f"Unknown retained event IDs: {', '.join(unknown)}.")
+    retained = frozenset(requested)
+    selected = tuple(event for event in events if event.event_id in retained)
+    return RetainedEventReplayPlan(
+        retained_event_ids=tuple(event.event_id for event in selected),
+        omitted_event_ids=tuple(event.event_id for event in events if event.event_id not in retained),
+        events=selected,
+    )
+
+
+def replay_retained_events(trace: SearchTrace, event_ids: tuple[str, ...] | None = None) -> RetainedEventReplayResult:
+    """Replay only retained root-backup contributions from a trace.
+
+    Each retained event contributes its recorded root backup delta to the
+    initialized root state.  Omitted events are neither replayed as structural
+    prerequisites nor used to restore visits or values, which lets sparse and
+    non-contiguous selections remain explicit counterfactuals.
+    """
+    plan = plan_retained_events(trace, event_ids)
+    events = trace.events or ()
+    if not events:
+        raise ValueError("Replayable traces require at least one simulation event.")
+    initial = _retained_initial_root_state(events[0])
+    state = {edge.move: edge for edge in initial}
+    for event in plan.events:
+        move, before, after = _retained_root_transition(event, set(state))
+        state[move] = _apply_retained_root_delta(state[move], before, after, event)
+    root_statistics = tuple(state[move] for move in sorted(state))
+    total_visits = sum(edge.visits or 0 for edge in root_statistics)
+    root_policy = tuple(
+        (edge.move, 0.0 if total_visits == 0 else (edge.visits or 0) / total_visits) for edge in root_statistics
+    )
+    best_visits = max(edge.visits or 0 for edge in root_statistics)
+    selected_move = min(edge.move for edge in root_statistics if (edge.visits or 0) == best_visits)
+    costs = RetainedEventReplayCosts(
+        simulations=len(plan.events),
+        evaluator_calls=sum(event.leaf.evaluator is not None for event in plan.events),
+        expansions=sum(event.expansion is not None for event in plan.events),
+        backup_updates=sum(len(event.backups) for event in plan.events),
+    )
+    result = RetainedEventReplayResult(root_statistics, root_policy, selected_move, plan, costs)
+    if len(plan.events) == len(events):
+        semantic = replay_search_trace(trace)
+        if (
+            len(result.root_statistics) != len(semantic.root_statistics)
+            or any(
+                not _same_edge(left, right) for left, right in zip(result.root_statistics, semantic.root_statistics)
+            )
+            or len(result.root_policy) != len(semantic.root_policy)
+            or any(
+                left[0] != right[0] or not _close(left[1], right[1])
+                for left, right in zip(result.root_policy, semantic.root_policy)
+            )
+            or result.selected_move != semantic.selected_move
+        ):
+            raise SemanticReplayError("full retained-event replay diverges from semantic replay.", phase="result")
+    return result
+
+
+def _retained_initial_root_state(event: SimulationEvent) -> tuple[EdgeStatistics, ...]:
+    initial = event.root_before
+    if not initial:
+        raise ValueError(f"Event {event.event_id} needs a non-empty initial root state.")
+    state = {edge.move: edge for edge in initial}
+    if len(state) != len(initial):
+        raise ValueError(f"Event {event.event_id} has duplicate root moves.")
+    return initial
+
+
+def _retained_root_transition(
+    event: SimulationEvent, expected_moves: set[str]
+) -> tuple[str, EdgeStatistics, EdgeStatistics]:
+    before = {edge.move: edge for edge in event.root_before or ()}
+    after = {edge.move: edge for edge in event.root_after or ()}
+    if len(before) != len(event.root_before or ()) or len(after) != len(event.root_after or ()):
+        raise ValueError(f"Event {event.event_id} has duplicate root moves.")
+    if before.keys() != after.keys() or before.keys() != expected_moves:
+        raise ValueError(f"Event {event.event_id} changes the root move set.")
+    changed = [move for move in before if before[move] != after[move]]
+    if len(changed) != 1:
+        raise ValueError(f"Event {event.event_id} must change exactly one root edge.")
+    move = changed[0]
+    if not any(update.before == before[move] and update.after == after[move] for update in event.backups):
+        raise ValueError(f"Event {event.event_id} has no matching root backup.")
+    return move, before[move], after[move]
+
+
+def _apply_retained_root_delta(
+    current: EdgeStatistics, before: EdgeStatistics, after: EdgeStatistics, event: SimulationEvent
+) -> EdgeStatistics:
+    if current.move != before.move or current.perspective is not before.perspective:
+        raise ValueError(f"Event {event.event_id} has incompatible root-edge evidence.")
+    if current.prior != before.prior or after.prior != before.prior:
+        raise ValueError(f"Event {event.event_id} changes a root prior.")
+    before_visits, after_visits = before.visits, after.visits
+    before_value, after_value = before.total_value, after.total_value
+    if before_visits is None or after_visits is None or before_value is None or after_value is None:
+        raise ValueError(f"Event {event.event_id} needs root visit and value evidence.")
+    visits = (current.visits or 0) + after_visits - before_visits
+    total_value = (current.total_value or 0.0) + after_value - before_value
+    if visits < 0:
+        raise ValueError(f"Event {event.event_id} would make root visits negative.")
+    return EdgeStatistics(
+        move=current.move,
+        perspective=current.perspective,
+        prior=current.prior,
+        visits=visits,
+        total_value=total_value,
+        mean_value=0.0 if visits == 0 else total_value / visits,
+    )
 
 
 def replay_search_trace(trace: SearchTrace) -> SemanticReplayResult:
@@ -681,8 +845,13 @@ def _close(left: float | None, right: float | None) -> bool:
 __all__ = [
     "Evaluator",
     "ReferenceMCTS",
+    "RetainedEventReplayCosts",
+    "RetainedEventReplayPlan",
+    "RetainedEventReplayResult",
     "SemanticReplayError",
     "SemanticReplayResult",
+    "plan_retained_events",
     "replay_root_events",
+    "replay_retained_events",
     "replay_search_trace",
 ]

--- a/src/lczerolens/reference_search.py
+++ b/src/lczerolens/reference_search.py
@@ -7,7 +7,7 @@ reuse, transpositions, pruning, or FPU behaviour.  It emits the public
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import math
 from typing import Callable, Protocol
 
@@ -394,7 +394,7 @@ def replay_retained_events(trace: SearchTrace, event_ids: tuple[str, ...] | None
     for event in plan.events:
         move, before, after = _retained_root_transition(event, set(state))
         state[move] = _apply_retained_root_delta(state[move], before, after, event)
-    root_statistics = tuple(state[move] for move in sorted(state))
+    root_statistics = tuple(replace(state[move], exploration=None) for move in sorted(state))
     total_visits = sum(edge.visits or 0 for edge in root_statistics)
     root_policy = tuple(
         (edge.move, 0.0 if total_visits == 0 else (edge.visits or 0) / total_visits) for edge in root_statistics
@@ -413,7 +413,9 @@ def replay_retained_events(trace: SearchTrace, event_ids: tuple[str, ...] | None
         final_statistics = tuple(action.statistics for action in final.actions or ())
         if (
             len(result.root_statistics) != len(final_statistics)
-            or any(not _same_edge(left, right) for left, right in zip(result.root_statistics, final_statistics))
+            or any(
+                not _same_retained_edge(left, right) for left, right in zip(result.root_statistics, final_statistics)
+            )
             or final.selection is None
             or result.selected_move != final.selection.move
         ):
@@ -828,6 +830,18 @@ def _same_edge(left: EdgeStatistics, right: EdgeStatistics) -> bool:
         and _close(left.total_value, right.total_value)
         and _close(left.mean_value, right.mean_value)
         and _close(left.exploration, right.exploration)
+    )
+
+
+def _same_retained_edge(left: EdgeStatistics, right: EdgeStatistics) -> bool:
+    """Compare replayed root statistics without producer-specific U evidence."""
+    return (
+        left.move == right.move
+        and left.perspective is right.perspective
+        and _close(left.prior, right.prior)
+        and left.visits == right.visits
+        and _close(left.total_value, right.total_value)
+        and _close(left.mean_value, right.mean_value)
     )
 
 

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -25,6 +25,7 @@ from lczerolens.search_trace import (
     EdgeStatistics,
     LeafRecord,
     PositionEvaluation,
+    RootAction,
     SearchCapability,
     SearchProvenance,
     SimulationEvent,
@@ -152,6 +153,36 @@ def test_full_retained_replay_is_not_limited_to_reference_mcts_provenance():
 
     assert result.root_statistics == tuple(action.statistics for action in other_provider.snapshots[-1].actions)
     assert result.selected_move == other_provider.snapshots[-1].selection.move
+
+
+def test_retained_event_replay_clears_provider_specific_exploration_evidence():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    before = tuple(replace(edge, exploration=0.5) for edge in event.root_before)
+    after = tuple(replace(edge, exploration=0.5) for edge in event.root_after)
+    before_by_move = {edge.move: edge for edge in before}
+    after_by_move = {edge.move: edge for edge in after}
+    root_backup = event.backups[0]
+    explored_event = replace(
+        event,
+        root_before=before,
+        root_after=after,
+        backups=(
+            replace(
+                root_backup,
+                before=before_by_move[root_backup.before.move],
+                after=after_by_move[root_backup.after.move],
+            ),
+        ),
+    )
+    snapshot = replace(trace.snapshots[-1], actions=tuple(RootAction(edge) for edge in after))
+    explored_trace = replace(trace, events=(explored_event,), snapshots=(snapshot,))
+
+    full = replay_retained_events(explored_trace)
+    empty = replay_retained_events(explored_trace, ())
+
+    assert all(edge.exploration is None for edge in full.root_statistics)
+    assert all(edge.exploration is None for edge in empty.root_statistics)
 
 
 def test_retained_event_replay_rejects_missing_or_malformed_retained_evidence():

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -11,6 +11,8 @@ from lczerolens.reference_search import (
     ReferenceMCTS,
     SemanticReplayError,
     _Node,
+    plan_retained_events,
+    replay_retained_events,
     _replay_path,
     replay_root_events,
     replay_search_trace,
@@ -98,6 +100,44 @@ def test_semantic_replay_reconstructs_representative_search_results(fen, simulat
     assert result.root_statistics == tuple(action.statistics for action in trace.snapshots[-1].actions)
     assert sum(probability for _, probability in result.root_policy) == pytest.approx(1.0)
     assert result.selected_move == trace.snapshots[-1].selection.move
+
+
+def test_retained_event_replay_supports_full_prefix_sparse_singleton_empty_and_complement_selections():
+    trace = ReferenceMCTS(c_puct=1.5).search(LczeroBoard(), FixedEvaluator(), simulations=8)
+    event_ids = tuple(event.event_id for event in trace.events)
+
+    full = replay_retained_events(trace)
+    prefix = replay_retained_events(trace, event_ids[:3])
+    sparse = replay_retained_events(trace, event_ids[::2])
+    singleton = replay_retained_events(trace, (event_ids[4],))
+    empty = replay_retained_events(trace, ())
+    complement = replay_retained_events(trace, event_ids[1::2])
+
+    assert full.root_statistics == pytest.approx(replay_search_trace(trace).root_statistics)
+    assert full.selected_move == trace.snapshots[-1].selection.move
+    assert prefix.costs.simulations == 3
+    assert sparse.costs.simulations == 4
+    assert singleton.costs.simulations == 1
+    assert empty.costs.simulations == 0
+    assert sum(edge.visits or 0 for edge in empty.root_statistics) == 0
+    assert tuple(event.event_id for event in sparse.plan.events) == event_ids[::2]
+    assert [edge.visits for edge in full.root_statistics] == [
+        (left.visits or 0) + (right.visits or 0)
+        for left, right in zip(sparse.root_statistics, complement.root_statistics)
+    ]
+
+
+def test_retained_event_plan_preserves_trace_order_and_rejects_ambiguous_selections():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=3)
+    first, second, third = (event.event_id for event in trace.events)
+
+    plan = plan_retained_events(trace, (third, first))
+
+    assert plan.retained_event_ids == (first, third)
+    with pytest.raises(ValueError, match="must be unique"):
+        plan_retained_events(trace, (first, first))
+    with pytest.raises(ValueError, match="Unknown retained"):
+        plan_retained_events(trace, (second, "missing"))
 
 
 def test_semantic_replay_preserves_root_history_for_fivefold_repetition():

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -11,6 +11,9 @@ from lczerolens.reference_search import (
     ReferenceMCTS,
     SemanticReplayError,
     _Node,
+    _apply_retained_root_delta,
+    _retained_initial_root_state,
+    _retained_root_transition,
     plan_retained_events,
     replay_retained_events,
     _replay_path,
@@ -138,6 +141,55 @@ def test_retained_event_plan_preserves_trace_order_and_rejects_ambiguous_selecti
         plan_retained_events(trace, (first, first))
     with pytest.raises(ValueError, match="Unknown retained"):
         plan_retained_events(trace, (second, "missing"))
+
+
+def test_retained_event_replay_rejects_missing_or_malformed_retained_evidence():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=2)
+    event = trace.events[0]
+    before = event.root_before
+    after = event.root_after
+    assert before is not None and after is not None
+
+    with pytest.raises(ValueError, match="at least one"):
+        replay_retained_events(replace(trace, events=()))
+    with pytest.raises(ValueError, match="non-empty initial"):
+        _retained_initial_root_state(replace(event, root_before=()))
+    with pytest.raises(ValueError, match="duplicate root"):
+        _retained_initial_root_state(replace(event, root_before=(before[0], before[0])))
+    with pytest.raises(ValueError, match="duplicate root"):
+        _retained_root_transition(replace(event, root_before=(before[0], before[0])), set())
+    with pytest.raises(ValueError, match="changes the root move set"):
+        _retained_root_transition(replace(event, root_after=after[:-1]), {edge.move for edge in before})
+    with pytest.raises(ValueError, match="exactly one root edge"):
+        _retained_root_transition(replace(event, root_after=before), {edge.move for edge in before})
+    with pytest.raises(ValueError, match="no matching root backup"):
+        _retained_root_transition(replace(event, backups=()), {edge.move for edge in before})
+
+
+def test_retained_root_delta_rejects_incompatible_or_incomplete_updates():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=1)
+    event = trace.events[0]
+    before = event.root_before
+    after = event.root_after
+    assert before is not None and after is not None
+    after_by_move = {edge.move: edge for edge in after}
+    move = next(edge.move for edge in before if edge != after_by_move[edge.move])
+    event_before = next(edge for edge in before if edge.move == move)
+    event_after = next(edge for edge in after if edge.move == move)
+
+    with pytest.raises(ValueError, match="incompatible"):
+        _apply_retained_root_delta(before[1], event_before, event_after, event)
+    with pytest.raises(ValueError, match="changes a root prior"):
+        _apply_retained_root_delta(event_before, event_before, replace(event_after, prior=1.0), event)
+    with pytest.raises(ValueError, match="root visit and value"):
+        _apply_retained_root_delta(event_before, replace(event_before, visits=None), event_after, event)
+    with pytest.raises(ValueError, match="root visits negative"):
+        _apply_retained_root_delta(
+            event_before,
+            replace(event_before, visits=1, total_value=0.0, mean_value=0.0),
+            replace(event_after, visits=0, total_value=0.0, mean_value=0.0),
+            event,
+        )
 
 
 def test_semantic_replay_preserves_root_history_for_fivefold_repetition():

--- a/tests/unit/test_reference_search.py
+++ b/tests/unit/test_reference_search.py
@@ -26,6 +26,7 @@ from lczerolens.search_trace import (
     LeafRecord,
     PositionEvaluation,
     SearchCapability,
+    SearchProvenance,
     SimulationEvent,
     ValuePerspective,
     Wdl,
@@ -141,6 +142,16 @@ def test_retained_event_plan_preserves_trace_order_and_rejects_ambiguous_selecti
         plan_retained_events(trace, (first, first))
     with pytest.raises(ValueError, match="Unknown retained"):
         plan_retained_events(trace, (second, "missing"))
+
+
+def test_full_retained_replay_is_not_limited_to_reference_mcts_provenance():
+    trace = ReferenceMCTS().search(LczeroBoard(), FixedEvaluator(), simulations=2)
+    other_provider = replace(trace, provenance=SearchProvenance(source="external-search", engine="external"))
+
+    result = replay_retained_events(other_provider)
+
+    assert result.root_statistics == tuple(action.statistics for action in other_provider.snapshots[-1].actions)
+    assert result.selected_move == other_provider.snapshots[-1].selection.move
 
 
 def test_retained_event_replay_rejects_missing_or_malformed_retained_evidence():


### PR DESCRIPTION
## Summary

- add ordered retained-event replay plans and explicit retained-work counts
- replay only selected root backup deltas, with sparse and empty selections supported
- expose the public API and cover full, prefix, sparse, singleton, empty, and complement selections

## Why

This provides the retained-event replay capability required for trace-reduction experiments without silently restoring omitted backup contributions.

Closes #156

## Validation

- `just checks`
- `just tests` (284 passed; 90.11% coverage)