### PR TITLE
Add canonical SearchTrace serialization and stable digests

### DIFF
--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -7,10 +7,12 @@ must stay ``None`` rather than being reconstructed or guessed by an adapter.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import TypeAlias
+from typing import Any, TypeAlias
 
 import chess
 
@@ -44,6 +46,10 @@ _CAPABILITY_LEVEL = {
 
 class SearchCapabilityError(RuntimeError):
     """Raised when a consumer asks a trace for evidence it does not contain."""
+
+
+class SearchTraceFormatError(ValueError):
+    """Raised when persisted search-trace bytes do not match the canonical format."""
 
 
 class ValuePerspective(str, Enum):
@@ -90,6 +96,8 @@ class SearchParameter:
     def __post_init__(self) -> None:
         if not self.name:
             raise ValueError("Search parameter names must not be empty.")
+        if self.value is not None and not isinstance(self.value, str | int | float | bool):
+            raise ValueError(f"Search parameter {self.name!r} has an unsupported value type.")
         if isinstance(self.value, float) and not math.isfinite(self.value):
             raise ValueError(f"Search parameter {self.name!r} must be finite.")
 
@@ -532,6 +540,161 @@ class SearchTrace:
         return self
 
 
+_SEARCH_TRACE_FORMAT = "lczerolens.search-trace"
+_SEARCH_TRACE_FORMAT_VERSION = 1
+_SEARCH_TRACE_TYPES = {
+    record_type.__name__: record_type
+    for record_type in (
+        BackupUpdate,
+        EdgeStatistics,
+        EvaluatorCall,
+        LeafRecord,
+        NodeExpansion,
+        PathStep,
+        PositionEvaluation,
+        PrincipalVariation,
+        RootAction,
+        RootSelection,
+        RootSnapshot,
+        SearchBudget,
+        SearchParameter,
+        SearchProvenance,
+        SearchTrace,
+        SimulationEvent,
+        Wdl,
+    )
+}
+_SEARCH_TRACE_ENUMS = {
+    enum_type.__name__: enum_type
+    for enum_type in (
+        ChessPlayer,
+        SearchBudgetUnit,
+        SearchCapability,
+        ValuePerspective,
+    )
+}
+
+
+def _canonical_record(value: Any) -> Any:
+    """Convert supported trace values to a JSON-compatible typed record."""
+    if is_dataclass(value) and not isinstance(value, type):
+        return {
+            "$type": type(value).__name__,
+            **{item.name: _canonical_record(getattr(value, item.name)) for item in fields(value)},
+        }
+    if isinstance(value, Enum):
+        return {"$enum": type(value).__name__, "value": value.value}
+    if isinstance(value, tuple):
+        return [_canonical_record(item) for item in value]
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            raise SearchTraceFormatError("Canonical search traces cannot contain non-finite floats.")
+        return int(value) if value.is_integer() else value
+    if value is None or isinstance(value, str | int | bool):
+        return value
+    raise SearchTraceFormatError(f"Unsupported search-trace value {type(value).__name__!r}.")
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    record: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in record:
+            raise SearchTraceFormatError(f"Duplicate JSON field {key!r}.")
+        record[key] = value
+    return record
+
+
+def _decode_record(value: Any) -> Any:
+    """Decode one typed canonical record without supplying schema defaults."""
+    if isinstance(value, list):
+        return tuple(_decode_record(item) for item in value)
+    if not isinstance(value, dict):
+        return value
+    if "$enum" in value:
+        if set(value) != {"$enum", "value"}:
+            raise SearchTraceFormatError("Enum records must contain exactly '$enum' and 'value'.")
+        enum_name = value["$enum"]
+        if not isinstance(enum_name, str):
+            raise SearchTraceFormatError("Search-trace enum names must be strings.")
+        enum_type = _SEARCH_TRACE_ENUMS.get(enum_name)
+        if enum_type is None:
+            raise SearchTraceFormatError(f"Unknown search-trace enum {enum_name!r}.")
+        try:
+            return enum_type(value["value"])
+        except (TypeError, ValueError) as error:
+            raise SearchTraceFormatError(f"Invalid {enum_name} value {value['value']!r}.") from error
+    if "$type" not in value:
+        raise SearchTraceFormatError("Nested search-trace objects require a '$type' field.")
+    type_name = value["$type"]
+    if not isinstance(type_name, str):
+        raise SearchTraceFormatError("Search-trace record type names must be strings.")
+    record_type = _SEARCH_TRACE_TYPES.get(type_name)
+    if record_type is None:
+        raise SearchTraceFormatError(f"Unknown search-trace record type {type_name!r}.")
+    expected_fields = {item.name for item in fields(record_type)}
+    actual_fields = set(value) - {"$type"}
+    if actual_fields != expected_fields:
+        missing = sorted(expected_fields - actual_fields)
+        unexpected = sorted(actual_fields - expected_fields)
+        raise SearchTraceFormatError(f"Invalid {type_name} fields: missing={missing!r}, unexpected={unexpected!r}.")
+    values = {name: _decode_record(value[name]) for name in expected_fields}
+    if record_type is SearchTrace:
+        schema_version = values.pop("schema_version")
+        if isinstance(schema_version, bool) or schema_version != 1:
+            raise SearchTraceFormatError(f"Unsupported SearchTrace schema version {schema_version!r}.")
+    try:
+        return record_type(**values)
+    except (TypeError, ValueError) as error:
+        raise SearchTraceFormatError(f"Invalid {type_name} record: {error}") from error
+
+
+def serialize_search_trace(trace: SearchTrace) -> bytes:
+    """Return the version-1 canonical UTF-8 JSON representation of ``trace``."""
+    if not isinstance(trace, SearchTrace):
+        raise TypeError("serialize_search_trace expects a SearchTrace.")
+    envelope = {
+        "format": _SEARCH_TRACE_FORMAT,
+        "format_version": _SEARCH_TRACE_FORMAT_VERSION,
+        "trace": _canonical_record(trace),
+    }
+    return json.dumps(
+        envelope,
+        allow_nan=False,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def deserialize_search_trace(data: bytes) -> SearchTrace:
+    """Load a trace from canonical bytes, rejecting malformed or incompatible records."""
+    if not isinstance(data, bytes):
+        raise TypeError("deserialize_search_trace expects bytes.")
+    try:
+        envelope = json.loads(data.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys)
+    except SearchTraceFormatError:
+        raise
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise SearchTraceFormatError(f"Invalid search-trace JSON: {error}") from error
+    if not isinstance(envelope, dict) or set(envelope) != {"format", "format_version", "trace"}:
+        raise SearchTraceFormatError("Search-trace envelopes require exactly 'format', 'format_version', and 'trace'.")
+    if envelope["format"] != _SEARCH_TRACE_FORMAT:
+        raise SearchTraceFormatError(f"Unsupported search-trace format {envelope['format']!r}.")
+    if isinstance(envelope["format_version"], bool) or envelope["format_version"] != _SEARCH_TRACE_FORMAT_VERSION:
+        raise SearchTraceFormatError(f"Unsupported search-trace format version {envelope['format_version']!r}.")
+    trace = _decode_record(envelope["trace"])
+    if not isinstance(trace, SearchTrace):
+        raise SearchTraceFormatError("The canonical envelope must contain a SearchTrace record.")
+    if serialize_search_trace(trace) != data:
+        raise SearchTraceFormatError("Search-trace bytes are valid JSON but are not canonical.")
+    return trace
+
+
+def search_trace_digest(trace: SearchTrace) -> str:
+    """Return the lowercase SHA-256 digest of the canonical trace bytes."""
+    return hashlib.sha256(serialize_search_trace(trace)).hexdigest()
+
+
 __all__ = [
     "BackupUpdate",
     "ChessPlayer",
@@ -550,10 +713,14 @@ __all__ = [
     "SearchBudgetUnit",
     "SearchCapability",
     "SearchCapabilityError",
+    "SearchTraceFormatError",
     "SearchParameter",
     "SearchProvenance",
     "SearchTrace",
     "SimulationEvent",
     "ValuePerspective",
     "Wdl",
+    "deserialize_search_trace",
+    "search_trace_digest",
+    "serialize_search_trace",
 ]

--- a/src/lczerolens/search_trace.py
+++ b/src/lczerolens/search_trace.py
@@ -12,7 +12,9 @@ import json
 import math
 from dataclasses import dataclass, field, fields, is_dataclass
 from enum import Enum
-from typing import Any, TypeAlias
+from functools import cache
+from types import UnionType
+from typing import Any, TypeAlias, Union, get_args, get_origin, get_type_hints
 
 import chess
 
@@ -604,6 +606,63 @@ def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
     return record
 
 
+@cache
+def _record_type_hints(record_type: type[Any]) -> dict[str, Any]:
+    """Resolve one record's annotations once for strict persisted-data validation."""
+    return get_type_hints(record_type)
+
+
+def _coerce_annotation(value: Any, annotation: Any) -> Any:
+    """Validate and minimally coerce a decoded JSON value to one field annotation."""
+    origin = get_origin(annotation)
+    if origin in (Union, UnionType):
+        options = get_args(annotation)
+        for option in options:
+            option_origin = get_origin(option)
+            if (option_origin is tuple and isinstance(value, tuple)) or (
+                isinstance(option, type) and type(value) is option
+            ):
+                return _coerce_annotation(value, option)
+        for option in options:
+            try:
+                return _coerce_annotation(value, option)
+            except TypeError:
+                continue
+        raise TypeError
+    if origin is tuple:
+        if not isinstance(value, tuple):
+            raise TypeError
+        arguments = get_args(annotation)
+        if len(arguments) == 2 and arguments[1] is Ellipsis:
+            return tuple(_coerce_annotation(item, arguments[0]) for item in value)
+        if len(value) != len(arguments):
+            raise TypeError
+        return tuple(_coerce_annotation(item, item_type) for item, item_type in zip(value, arguments))
+    if annotation is type(None):
+        if value is not None:
+            raise TypeError
+        return None
+    if annotation is float:
+        if isinstance(value, bool) or not isinstance(value, int | float):
+            raise TypeError
+        return float(value)
+    if annotation is int:
+        if isinstance(value, bool) or not isinstance(value, int):
+            raise TypeError
+        return value
+    if annotation is bool:
+        if not isinstance(value, bool):
+            raise TypeError
+        return value
+    if annotation is str:
+        if not isinstance(value, str):
+            raise TypeError
+        return value
+    if isinstance(annotation, type) and isinstance(value, annotation):
+        return value
+    raise TypeError
+
+
 def _decode_record(value: Any) -> Any:
     """Decode one typed canonical record without supplying schema defaults."""
     if isinstance(value, list):
@@ -638,13 +697,21 @@ def _decode_record(value: Any) -> Any:
         unexpected = sorted(actual_fields - expected_fields)
         raise SearchTraceFormatError(f"Invalid {type_name} fields: missing={missing!r}, unexpected={unexpected!r}.")
     values = {name: _decode_record(value[name]) for name in expected_fields}
+    annotations = _record_type_hints(record_type)
+    for name in expected_fields:
+        try:
+            values[name] = _coerce_annotation(values[name], annotations[name])
+        except TypeError as error:
+            raise SearchTraceFormatError(
+                f"Invalid {type_name}.{name}: value does not match its declared field type."
+            ) from error
     if record_type is SearchTrace:
         schema_version = values.pop("schema_version")
         if isinstance(schema_version, bool) or schema_version != 1:
             raise SearchTraceFormatError(f"Unsupported SearchTrace schema version {schema_version!r}.")
     try:
         return record_type(**values)
-    except (TypeError, ValueError) as error:
+    except (AttributeError, TypeError, ValueError) as error:
         raise SearchTraceFormatError(f"Invalid {type_name} record: {error}") from error
 
 
@@ -657,13 +724,16 @@ def serialize_search_trace(trace: SearchTrace) -> bytes:
         "format_version": _SEARCH_TRACE_FORMAT_VERSION,
         "trace": _canonical_record(trace),
     }
-    return json.dumps(
-        envelope,
-        allow_nan=False,
-        ensure_ascii=False,
-        separators=(",", ":"),
-        sort_keys=True,
-    ).encode("utf-8")
+    try:
+        return json.dumps(
+            envelope,
+            allow_nan=False,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+    except UnicodeEncodeError as error:
+        raise SearchTraceFormatError("Canonical search traces must contain valid UTF-8 strings.") from error
 
 
 def deserialize_search_trace(data: bytes) -> SearchTrace:

--- a/tests/unit/test_search_trace_serialization.py
+++ b/tests/unit/test_search_trace_serialization.py
@@ -1,0 +1,231 @@
+"""Canonical persistence contracts for search traces."""
+
+from dataclasses import replace
+
+import pytest
+
+from lczerolens.search_trace import (
+    BackupUpdate,
+    ChessPlayer,
+    EdgeStatistics,
+    EvaluatorCall,
+    LeafRecord,
+    NodeExpansion,
+    PathStep,
+    PositionEvaluation,
+    PrincipalVariation,
+    RootAction,
+    RootSelection,
+    RootSnapshot,
+    SearchBudget,
+    SearchBudgetUnit,
+    SearchCapability,
+    SearchParameter,
+    SearchProvenance,
+    SearchTrace,
+    SearchTraceFormatError,
+    SimulationEvent,
+    ValuePerspective,
+    Wdl,
+    deserialize_search_trace,
+    search_trace_digest,
+    serialize_search_trace,
+)
+
+
+START_FEN = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"
+FIXTURE_DIGEST = "144a0c0cca94ecaf696781b38da7f8aefed881b2c9c8335dcef7c854d0b7b8c0"
+
+
+def _full_trace() -> SearchTrace:
+    e2e4_before = EdgeStatistics(
+        "e2e4",
+        ValuePerspective.ROOT_PLAYER,
+        prior=0.6,
+        visits=0,
+        total_value=0.0,
+        mean_value=0.0,
+        exploration=0.2,
+    )
+    e2e4_after = replace(e2e4_before, visits=1, total_value=0.25, mean_value=0.25, exploration=0.1)
+    d2d4 = EdgeStatistics(
+        "d2d4",
+        ValuePerspective.ROOT_PLAYER,
+        prior=0.4,
+        visits=0,
+        total_value=0.0,
+        mean_value=0.0,
+        exploration=0.15,
+    )
+    leaf_evaluation = PositionEvaluation(
+        ValuePerspective.ROOT_PLAYER,
+        value=0.25,
+        wdl=Wdl(0.5, 0.25, 0.25, ValuePerspective.ROOT_PLAYER),
+    )
+    evaluator = EvaluatorCall(
+        dtype="float32",
+        source_device="mps:0",
+        search_device="cpu",
+        legal_policy_logits=(("e7e5", 2.5), ("c7c5", -0.5)),
+    )
+    event = SimulationEvent(
+        event_id="simulation-0",
+        simulation=0,
+        path=(PathStep("root", "e2e4", "node-e2e4"),),
+        leaf=LeafRecord("node-e2e4", leaf_evaluation, terminal=False, evaluator=evaluator),
+        backups=(BackupUpdate("root", 0.25, e2e4_before, e2e4_after),),
+        expansion=NodeExpansion(
+            "node-e2e4",
+            (EdgeStatistics("e7e5", ValuePerspective.SIDE_TO_MOVE, prior=1.0),),
+        ),
+        root_before=(e2e4_before, d2d4),
+        root_after=(e2e4_after, d2d4),
+    )
+    return SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.REPLAYABLE,
+        provenance=SearchProvenance(
+            source="reference-search",
+            engine="lczerolens",
+            engine_version="0.4.0",
+            network="fixture.pt",
+            network_checksum="sha256:0123456789abcdef",
+            parameters=(
+                SearchParameter("enabled", True),
+                SearchParameter("optional", None),
+                SearchParameter("seed", 7),
+                SearchParameter("temperature", 1.5),
+                SearchParameter("variant", "standard"),
+            ),
+        ),
+        snapshots=(
+            RootSnapshot(
+                sequence=0,
+                selection=RootSelection("e2e4", "maximum N", "UCI order", temperature=0.0),
+                evaluation=leaf_evaluation,
+                budget=SearchBudget(SearchBudgetUnit.SIMULATIONS, requested=1, observed=1),
+                actions=(
+                    RootAction(
+                        e2e4_after,
+                        evaluation=leaf_evaluation,
+                        leaf_evaluation=leaf_evaluation,
+                        principal_variation=PrincipalVariation(("e2e4", "e7e5")),
+                    ),
+                    RootAction(d2d4),
+                ),
+            ),
+        ),
+        events=(event,),
+        root_expansion=NodeExpansion("root", (e2e4_before, d2d4)),
+        root_evaluator=evaluator,
+        root_start_fen=START_FEN,
+        root_move_history=(),
+    )
+
+
+@pytest.mark.parametrize("capability", list(SearchCapability))
+def test_every_capability_round_trips_without_upgrading(capability):
+    trace = replace(_full_trace(), capability=capability)
+
+    loaded = deserialize_search_trace(serialize_search_trace(trace))
+
+    assert loaded == trace
+    assert loaded.capability is capability
+
+
+def test_absent_and_empty_collections_remain_distinct():
+    absent = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_RESULT,
+        provenance=SearchProvenance("fixture"),
+        snapshots=(RootSnapshot(0, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0)),),
+    )
+    empty = replace(absent, snapshots=(replace(absent.snapshots[0], actions=()),), events=())
+
+    assert serialize_search_trace(absent) != serialize_search_trace(empty)
+    assert deserialize_search_trace(serialize_search_trace(absent)).snapshots[0].actions is None
+    assert deserialize_search_trace(serialize_search_trace(empty)).snapshots[0].actions == ()
+    assert deserialize_search_trace(serialize_search_trace(absent)).events is None
+    assert deserialize_search_trace(serialize_search_trace(empty)).events == ()
+
+
+def test_equivalent_negative_zero_values_have_identical_bytes_and_digest():
+    positive = SearchTrace(
+        root_fen=START_FEN,
+        root_player=ChessPlayer.WHITE,
+        capability=SearchCapability.ROOT_RESULT,
+        provenance=SearchProvenance("fixture"),
+        snapshots=(RootSnapshot(0, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=0.0)),),
+    )
+    negative = replace(
+        positive,
+        snapshots=(RootSnapshot(0, evaluation=PositionEvaluation(ValuePerspective.ROOT_PLAYER, value=-0.0)),),
+    )
+
+    assert positive == negative
+    assert serialize_search_trace(positive) == serialize_search_trace(negative)
+    assert search_trace_digest(positive) == search_trace_digest(negative)
+
+
+def test_equivalent_integral_float_values_have_identical_bytes():
+    integer = replace(
+        _full_trace(),
+        provenance=replace(
+            _full_trace().provenance,
+            parameters=(SearchParameter("temperature", 1),),
+        ),
+    )
+    floating = replace(
+        integer,
+        provenance=replace(
+            integer.provenance,
+            parameters=(SearchParameter("temperature", 1.0),),
+        ),
+    )
+
+    assert integer == floating
+    assert serialize_search_trace(integer) == serialize_search_trace(floating)
+
+
+def test_canonical_fixture_and_expected_digest_are_stable():
+    fixture = serialize_search_trace(_full_trace())
+
+    assert search_trace_digest(_full_trace()) == FIXTURE_DIGEST
+    assert deserialize_search_trace(fixture) == _full_trace()
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "message"),
+    [
+        (b'"format_version":1', b'"format_version":2', "format version"),
+        (b'"schema_version":1', b'"schema_version":2', "schema version"),
+        (b'"$type":"SearchTrace"', b'"$type":"FutureTrace"', "record type"),
+        (b'"root_fen":', b'"unexpected":null,"root_fen":', "unexpected"),
+    ],
+)
+def test_incompatible_or_unknown_records_are_rejected(old, new, message):
+    malformed = serialize_search_trace(_full_trace()).replace(old, new, 1)
+
+    with pytest.raises(SearchTraceFormatError, match=message):
+        deserialize_search_trace(malformed)
+
+
+def test_duplicate_and_noncanonical_json_are_rejected():
+    duplicate = serialize_search_trace(_full_trace()).replace(
+        b'{"format":', b'{"format":"lczerolens.search-trace","format":', 1
+    )
+    with pytest.raises(SearchTraceFormatError, match="Duplicate JSON field"):
+        deserialize_search_trace(duplicate)
+    with pytest.raises(SearchTraceFormatError, match="not canonical"):
+        deserialize_search_trace(serialize_search_trace(_full_trace()) + b"\n")
+
+
+def test_serialization_entry_points_require_their_documented_types():
+    with pytest.raises(TypeError, match="SearchTrace"):
+        serialize_search_trace("not a trace")  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="bytes"):
+        deserialize_search_trace("not bytes")  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="unsupported value type"):
+        SearchParameter("nested", ())  # type: ignore[arg-type]

--- a/tests/unit/test_search_trace_serialization.py
+++ b/tests/unit/test_search_trace_serialization.py
@@ -267,8 +267,64 @@ def test_malformed_envelopes_are_rejected(data, message):
 def test_boolean_schema_version_is_rejected():
     malformed = serialize_search_trace(_full_trace()).replace(b'"schema_version":1', b'"schema_version":true', 1)
 
-    with pytest.raises(SearchTraceFormatError, match="schema version"):
+    with pytest.raises(SearchTraceFormatError, match="SearchTrace.schema_version"):
         deserialize_search_trace(malformed)
+
+
+@pytest.mark.parametrize(
+    ("old", "new", "field"),
+    [
+        (b'"terminal":false', b'"terminal":"false"', "LeafRecord.terminal"),
+        (
+            b'{"$enum":"SearchBudgetUnit","value":"simulations"}',
+            b'"simulations"',
+            "SearchBudget.unit",
+        ),
+        (b'"simulation":0', b'"simulation":true', "SimulationEvent.simulation"),
+        (
+            b'{"$type":"SearchParameter","name":"enabled","value":true}',
+            b"null",
+            "SearchProvenance.parameters",
+        ),
+    ],
+)
+def test_declared_field_types_cannot_be_bypassed(old, new, field):
+    malformed = serialize_search_trace(_full_trace()).replace(old, new, 1)
+
+    with pytest.raises(SearchTraceFormatError, match=field):
+        deserialize_search_trace(malformed)
+
+
+def test_integral_json_numbers_are_restored_to_declared_float_fields():
+    loaded = deserialize_search_trace(serialize_search_trace(_full_trace()))
+
+    assert type(loaded.events[0].root_before[0].total_value) is float
+    assert type(loaded.snapshots[0].budget.requested) is int
+
+
+@pytest.mark.parametrize(
+    ("value", "annotation"),
+    [
+        (None, tuple[str, ...]),
+        (("only-one",), tuple[str, int]),
+        ("not-numeric", float | None),
+        (1, str),
+    ],
+)
+def test_annotation_validation_fails_closed_for_every_supported_shape(value, annotation):
+    with pytest.raises(TypeError):
+        search_trace_module._coerce_annotation(value, annotation)
+
+
+def test_lone_surrogates_are_rejected_at_the_utf8_boundary():
+    trace = _full_trace()
+    malformed_trace = replace(trace, provenance=replace(trace.provenance, source="\ud800"))
+    with pytest.raises(SearchTraceFormatError, match="valid UTF-8"):
+        serialize_search_trace(malformed_trace)
+
+    malformed_bytes = serialize_search_trace(trace).replace(b'"source":"reference-search"', b'"source":"\\ud800"')
+    with pytest.raises(SearchTraceFormatError, match="valid UTF-8"):
+        deserialize_search_trace(malformed_bytes)
 
 
 def test_duplicate_and_noncanonical_json_are_rejected():

--- a/tests/unit/test_search_trace_serialization.py
+++ b/tests/unit/test_search_trace_serialization.py
@@ -1,9 +1,11 @@
 """Canonical persistence contracts for search traces."""
 
 from dataclasses import replace
+import math
 
 import pytest
 
+import lczerolens.search_trace as search_trace_module
 from lczerolens.search_trace import (
     BackupUpdate,
     ChessPlayer,
@@ -209,6 +211,63 @@ def test_incompatible_or_unknown_records_are_rejected(old, new, message):
     malformed = serialize_search_trace(_full_trace()).replace(old, new, 1)
 
     with pytest.raises(SearchTraceFormatError, match=message):
+        deserialize_search_trace(malformed)
+
+
+@pytest.mark.parametrize("value", [math.inf, object()])
+def test_unsupported_canonical_values_are_rejected(value):
+    with pytest.raises(SearchTraceFormatError, match="non-finite|Unsupported"):
+        search_trace_module._canonical_record(value)
+
+
+@pytest.mark.parametrize(
+    ("record", "message"),
+    [
+        ({"$enum": "ChessPlayer", "value": "white", "extra": None}, "exactly"),
+        ({"$enum": 1, "value": "white"}, "enum names"),
+        ({"$enum": "FutureEnum", "value": "white"}, "Unknown search-trace enum"),
+        ({"$enum": "ChessPlayer", "value": "green"}, "Invalid ChessPlayer"),
+        ({"value": "white"}, "require a '\\$type'"),
+        ({"$type": 1}, "type names"),
+        ({"$type": "SearchParameter", "name": "fixture"}, "missing"),
+        ({"$type": "SearchParameter", "name": "", "value": 1}, "Invalid SearchParameter"),
+    ],
+)
+def test_malformed_nested_records_are_rejected(record, message):
+    with pytest.raises(SearchTraceFormatError, match=message):
+        search_trace_module._decode_record(record)
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (b"\xff", "Invalid search-trace JSON"),
+        (b"{", "Invalid search-trace JSON"),
+        (b"null", "envelopes require"),
+        (b"{}", "envelopes require"),
+        (
+            b'{"format":"another-format","format_version":1,"trace":null}',
+            "Unsupported search-trace format",
+        ),
+        (
+            b'{"format":"lczerolens.search-trace","format_version":true,"trace":null}',
+            "format version",
+        ),
+        (
+            b'{"format":"lczerolens.search-trace","format_version":1,"trace":null}',
+            "must contain a SearchTrace",
+        ),
+    ],
+)
+def test_malformed_envelopes_are_rejected(data, message):
+    with pytest.raises(SearchTraceFormatError, match=message):
+        deserialize_search_trace(data)
+
+
+def test_boolean_schema_version_is_rejected():
+    malformed = serialize_search_trace(_full_trace()).replace(b'"schema_version":1', b'"schema_version":true', 1)
+
+    with pytest.raises(SearchTraceFormatError, match="schema version"):
         deserialize_search_trace(malformed)
 
 


### PR DESCRIPTION
## Summary

- add a versioned canonical UTF-8 JSON representation for every `SearchTrace` record and enum
- add strict deserialization that rejects duplicate, malformed, non-canonical, unknown, or incompatible records without filling missing evidence
- add stable SHA-256 trace digests with canonical normalization for equivalent integral numeric values
- preserve absent values separately from empty collections and retain the exact advertised capability

## Validation

- `just checks`
- `just tests` (`303 passed, 13 deselected`; 90.38% coverage)

Closes #157