### PR TITLE
Fix v0.5.0 docs selector

### DIFF
--- a/docs/source/_static/switcher.json
+++ b/docs/source/_static/switcher.json
@@ -4,6 +4,10 @@
       "url": "https://lczerolens.readthedocs.io/en/latest/"
     },
     {
+      "version": "v0.5.0",
+      "url": "https://lczerolens.readthedocs.io/en/v0.5.0/"
+    },
+    {
       "version": "v0.4.0",
       "url": "https://lczerolens.readthedocs.io/en/v0.4.0/"
     },

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -65,7 +65,9 @@ release = lczerolens.__version__
 # If READTHEDOCS_VERSION doesn't exist, we're not on RTD
 # If it is an integer, we're in a PR build and the version isn't correct.
 # If it's "latest" → change to "dev"
-if not version_match or version_match.isdigit() or version_match == "latest":
+if version_match == "latest":
+    version_match = "dev"
+elif not version_match or version_match.isdigit():
     # For local development, infer the version to match from the package.
     if "dev" in release or "rc" in release:
         version_match = "dev"


### PR DESCRIPTION
## Summary

- add `v0.5.0` to the documentation version manifest
- map Read the Docs' `latest` build to the selector's `dev` entry
- preserve release and local matching against the package version

## Root cause

The release documentation was deployed, but the shared switcher manifest still ended at `v0.4.0`. The Sphinx configuration also grouped the `latest` slug with local version inference, causing the development build to identify itself as `v0.5.0` instead of `dev`.

## User impact

The `v0.5.0` and `latest` documentation pages will identify their current version correctly, and users can navigate to `v0.5.0` from the selector.

## Validation

- `READTHEDOCS_VERSION=latest just docs`
- verified generated HTML uses `theme_switcher_version_match = 'dev'`
- verified `READTHEDOCS_VERSION=v0.5.0` resolves to `version_match = 'v0.5.0'`
- validated `switcher.json` with Python's JSON parser
- `uv run --group dev pre-commit run --files docs/source/conf.py docs/source/_static/switcher.json`
- `git diff --check`