### PR TITLE
Simplify documentation onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,38 +15,17 @@
 ![publish](https://github.com/Xmaster6y/lczerolens/actions/workflows/publish.yml/badge.svg)
 [![docs](https://readthedocs.org/projects/lczerolens/badge/?version=latest)](https://lczerolens.readthedocs.io/en/latest/?badge=latest)
 
-Leela Chess Zero (lc0) Lens (`lczerolens`) makes lc0-family models portable and operable in PyTorch, then expresses their evaluator and search behavior as chess-domain evidence. It provides the model and chess-analysis boundary; interpretability methods remain external integrations. See the [scope and compatibility policy](https://lczerolens.readthedocs.io/en/latest/scope.html).
+Portable PyTorch evaluation and chess-decision evidence for lc0-family models.
 
 ## Getting Started
 
-### Installs
-
-```bash
-pip install lczerolens
-```
-
-Loading or publishing models through Hugging Face Hub requires the `hub` extra:
+Install the package. Use the `hub` extra for the example below:
 
 ```bash
 pip install "lczerolens[hub]"
 ```
 
-### Tests
-
-After `just test-fixtures` has fetched and checksummed the lc0 fixtures, `just
-tests` runs the complete fast, offline suite (unit and conformance tests) and
-produces the coverage report. `just tests-unit` and `just tests-conformance`
-select either tier for diagnosis. The native Lczero bindings are a test-only
-conformance oracle, installed through the `conformance` dependency group rather
-than exposed as library API. Notebook and release checks are opt-in with
-`just tests-slow`; the notebook suite executes every maintained `.ipynb` page.
-`just tests-wheel` builds and installs the wheel in a fresh virtual
-environment before running the maintained workflow. CI retains JUnit and
-coverage artifacts to make failures inspectable.
-
-### Evaluate a position
-
-Get the best move predicted by a model:
+Evaluate a position:
 
 ```python
 import chess
@@ -54,92 +33,32 @@ from lczerolens import LczeroEvaluator, LczeroModel
 
 model = LczeroModel.from_hf("lczerolens/maia-1100")
 evaluator = LczeroEvaluator(model)
-board = chess.Board()
+evaluation = evaluator.evaluate(chess.Board())
 
-evaluation = evaluator.evaluate(board)
 print(evaluation.policy.best_move)
 print(evaluation.policy["e2e4"].probability)
 ```
 
-### External Interpretability Integrations
+## Examples
 
-Use `lczerolens` with your preferred PyTorch interpretability framework
-(`tdhook`, `captum`, `zennit`, or `nnsight`). These packages own their methods;
-they are not lczerolens abstractions or dependencies of its evaluator contract.
+- [Model inputs and loading](https://lczerolens.readthedocs.io/en/latest/notebooks/features/models-and-inputs.html)
+- [Evaluate positions and batches](https://lczerolens.readthedocs.io/en/latest/notebooks/features/evaluate-positions.html)
+- [Chess evidence: moves, lines, puzzles, and counterfactuals](https://lczerolens.readthedocs.io/en/latest/notebooks/features/chess-evidence.html)
+- [Search and replay](https://lczerolens.readthedocs.io/en/latest/notebooks/features/replayable-search.html)
+- [Complete decision-analysis tutorial](examples/decision_analysis_tutorial.py)
 
-```python
-import chess
-from lczerolens import LczeroEvaluator, LczeroKeys, LczeroModel
-from tdhook.attribution import Saliency
-from tensordict import TensorDict
+For the package boundary and detailed guides, see the [documentation](https://lczerolens.readthedocs.io).
 
-model = LczeroModel.from_hf("lczerolens/maia-1100")
-evaluator = LczeroEvaluator(model)
-board = chess.Board()
+### Documentation map
 
-def best_logit_init_targets(td: TensorDict, _):
-    policy = td[LczeroKeys.NETWORK_POLICY_LOGITS]
-    best_logit = policy.max(dim=-1).values
-    return TensorDict(out=best_logit, batch_size=td.batch_size)
-
-saliency_context = Saliency(init_attr_targets=best_logit_init_targets)
-with saliency_context.prepare(evaluator.model) as hooked_model:
-    tensors = hooked_model(evaluator.prepare([board]))
-    evaluation = evaluator.finish([board], tensors)[0]
-    attr = tensors.get(("attr", "input", "planes"))
-```
-
-### Define and grade a puzzle
-
-Puzzle correctness comes from an authored solution tree rather than from model
-preference or chess terminality:
-
-```python
-import chess
-from lczerolens import Puzzle, PuzzleContinuation, PuzzleSolution
-
-board = chess.Board("7k/8/5KQ1/8/8/8/8/8 w - - 0 1")
-solution = PuzzleSolution((PuzzleContinuation("g6g7"),))
-puzzle = Puzzle.from_board(board, solution)
-
-attempt = puzzle.grade(["g6g7"])
-print(attempt.status)  # PuzzleStatus.SOLVED
-```
-
-Solution trees can retain alternative accepted moves and authored opponent
-replies. Provider-specific dataset ingestion remains outside the core package.
-
-### Decision-analysis documentation
-
-The maintained documentation covers the evaluator and position contract, exact
-facts and move/variation evidence, authored puzzles, constrained
-counterfactuals, typed search traces, and concrete decision comparisons. Start
-with the [scope and compatibility policy](https://lczerolens.readthedocs.io/en/latest/scope.html),
-then follow the [facts](https://lczerolens.readthedocs.io/en/latest/facts.html),
-[search](https://lczerolens.readthedocs.io/en/latest/search.html), and
-[use cases](https://lczerolens.readthedocs.io/en/latest/use-cases.html) guides.
-
-Interpretability techniques remain external integrations rather than
-lczerolens APIs.
-
-### Maintained demos
-
-The executable [decision-analysis tutorial](examples/decision_analysis_tutorial.py)
-composes evaluator, search, exact line analysis, and counterfactual comparison
-against a deterministic fixture. Seven maintained
-[feature and tutorial notebooks](docs/source/tutorials.rst) cover model loading
-and inputs, evaluation, chess evidence, search and replay, complete decision
-analysis, model comparison, and authored-puzzle analysis. Sphinx renders and
-executes them, and the integration tier executes the source notebooks directly.
-Historical notebooks built on removed APIs are not shipped.
-
-## Full Documentation
-
-See the full [documentation](https://lczerolens.readthedocs.io).
+- [Release use cases and required guarantees](https://lczerolens.readthedocs.io/en/latest/use-cases.html)
+- [Architecture](https://lczerolens.readthedocs.io/en/latest/architecture.html)
+- [Scope and compatibility](https://lczerolens.readthedocs.io/en/latest/scope.html)
+- [API reference](https://lczerolens.readthedocs.io/en/latest/api/index.html)
 
 ## Contribute
 
-See the guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md). Development and test commands live there rather than in the quick-start path.
 
 ## Citation
 

--- a/README.md
+++ b/README.md
@@ -49,13 +49,6 @@ print(evaluation.policy["e2e4"].probability)
 
 For the package boundary and detailed guides, see the [documentation](https://lczerolens.readthedocs.io).
 
-### Documentation map
-
-- [Release use cases and required guarantees](https://lczerolens.readthedocs.io/en/latest/use-cases.html)
-- [Architecture](https://lczerolens.readthedocs.io/en/latest/architecture.html)
-- [Scope and compatibility](https://lczerolens.readthedocs.io/en/latest/scope.html)
-- [API reference](https://lczerolens.readthedocs.io/en/latest/api/index.html)
-
 ## Contribute
 
 See [CONTRIBUTING.md](CONTRIBUTING.md). Development and test commands live there rather than in the quick-start path.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -12,5 +12,20 @@ The feature documentation is executable:
 * :doc:`notebooks/features/replayable-search` covers search results,
   capability checks, semantic replay, and retained-event replay.
 
-Use :doc:`facts` and :doc:`search` for the short semantic contracts behind
-those examples. Use :doc:`api/index` for signatures and fields.
+Reference guides
+----------------
+
+* :doc:`facts` and :doc:`search` define the evidence and search contracts.
+* :doc:`use-cases` states release workflows and their guarantees.
+* :doc:`architecture` and :doc:`scope` define system ownership and supported
+  compatibility.
+* :doc:`api/index` contains signatures and fields.
+
+.. toctree::
+   :hidden:
+
+   facts
+   search
+   use-cases
+   scope
+   architecture

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,15 +8,10 @@ lczerolens
     :maxdepth: 1
     :hidden:
 
-    start
-    features
-    tutorials
-    facts
-    search
-    use-cases
-    scope
-    architecture
-    api/index
+    Getting Started <start>
+    Features <features>
+    Tutorials <tutorials>
+    API Reference <api/index>
     About <about>
 
 .. grid:: 1 1 2 2
@@ -50,76 +45,14 @@ lczerolens
 
                   Get Started
 
-          .. button-ref:: use-cases
+          .. button-ref:: features
             :color: primary
             :outline:
 
-                Use Cases
+                Features
 
           .. button-ref:: api/index
             :color: primary
             :outline:
 
                 API Reference
-
-
-.. div:: sd-fs-1 sd-font-weight-bold sd-text-center sd-text-primary sd-mb-5
-
-  Find what you need
-
-.. grid:: 1 1 2 2
-    :class-container: features
-
-    .. grid-item::
-
-      .. div:: features-container
-
-        .. image:: _static/images/one.png
-          :width: 150
-
-        .. div::
-
-          **Examples**
-
-          Start with model loading, position evaluation, chess evidence, or replayable search.
-
-          :doc:`Open examples <tutorials>`
-
-    .. grid-item::
-
-      .. div:: features-container
-
-        .. image:: _static/images/two.png
-          :width: 150
-
-        .. div::
-
-          **Release use cases**
-
-          See supported workflows and the guarantees that make their outputs usable.
-
-          :doc:`Read use cases <use-cases>`
-
-    .. grid-item::
-
-      .. div:: features-container
-
-        .. div::
-
-          **Architecture**
-
-          See the chess, model, evaluator, and evidence boundaries.
-
-          :doc:`Read architecture <architecture>`
-
-    .. grid-item::
-
-      .. div:: features-container
-
-        .. div::
-
-          **API reference**
-
-          Browse the supported package surface.
-
-          :doc:`Open API reference <api/index>`

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -40,8 +40,7 @@ lczerolens
 
             lc0 interoperability and chess-decision analysis
 
-        **lczerolens** makes lc0-family models operable in PyTorch and turns their evaluator and search behavior into chess-domain evidence.
-        Interpretability frameworks such as `tdhook`, `captum`, `zennit`, and `nnsight` integrate at this boundary; they are not core abstractions.
+        PyTorch evaluation and chess-decision evidence for lc0-family models.
 
         .. div:: button-group
 
@@ -51,11 +50,11 @@ lczerolens
 
                   Get Started
 
-          .. button-ref:: tutorials
+          .. button-ref:: use-cases
             :color: primary
             :outline:
 
-                Tutorials
+                Use Cases
 
           .. button-ref:: api/index
             :color: primary
@@ -66,7 +65,7 @@ lczerolens
 
 .. div:: sd-fs-1 sd-font-weight-bold sd-text-center sd-text-primary sd-mb-5
 
-  Key Features
+  Find what you need
 
 .. grid:: 1 1 2 2
     :class-container: features
@@ -80,9 +79,11 @@ lczerolens
 
         .. div::
 
-          **Adaptability**
+          **Examples**
 
-          Load converted Lczero ONNX or serialized PyTorch networks through one TensorDict model boundary.
+          Start with model loading, position evaluation, chess evidence, or replayable search.
+
+          :doc:`Open examples <tutorials>`
 
     .. grid-item::
 
@@ -93,6 +94,32 @@ lczerolens
 
         .. div::
 
-          **Composable execution**
+          **Release use cases**
 
-          Run board-aware evaluation while external tools instrument the same TensorDict execution path.
+          See supported workflows and the guarantees that make their outputs usable.
+
+          :doc:`Read use cases <use-cases>`
+
+    .. grid-item::
+
+      .. div:: features-container
+
+        .. div::
+
+          **Architecture**
+
+          See the chess, model, evaluator, and evidence boundaries.
+
+          :doc:`Read architecture <architecture>`
+
+    .. grid-item::
+
+      .. div:: features-container
+
+        .. div::
+
+          **API reference**
+
+          Browse the supported package surface.
+
+          :doc:`Open API reference <api/index>`

--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -1,9 +1,6 @@
 Getting Started
 ===============
 
-``lczerolens`` loads lc0-family models into PyTorch and turns evaluator and
-search output into chess-domain evidence.
-
 Installation
 ------------
 
@@ -11,12 +8,24 @@ Installation
 
    pip install lczerolens
 
-Use ``pip install "lczerolens[hub]"`` for Hugging Face model loading.
+Use ``pip install "lczerolens[hub]"`` for Hugging Face model loading. Then run
+an evaluation:
 
-Learn by running
-----------------
+.. code-block:: python
 
-Start with the maintained notebooks:
+   import chess
+   from lczerolens import LczeroEvaluator, LczeroModel
+
+   model = LczeroModel.from_hf("lczerolens/maia-1100")
+   evaluator = LczeroEvaluator(model)
+   evaluation = evaluator.evaluate(chess.Board())
+
+   print(evaluation.policy.best_move)
+
+Examples
+--------
+
+Start with the notebook closest to your task:
 
 * :doc:`notebooks/features/models-and-inputs` — load a model and inspect its
   TensorDict inputs;
@@ -27,6 +36,6 @@ Start with the maintained notebooks:
 * :doc:`notebooks/features/replayable-search` — run and replay reference
   search.
 
-Then use :doc:`tutorials` for complete workflows. :doc:`scope` defines what
-the project owns, :doc:`architecture` defines the system contract, and
-:doc:`api/index` is the generated reference.
+For an end-to-end workflow, use :doc:`tutorials`. Project boundaries and the
+generated reference are in :doc:`scope`, :doc:`architecture`, and
+:doc:`api/index`.

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,11 +1,7 @@
 Tutorials
 =========
 
-The notebooks use small deterministic fixtures where a downloaded network or
-engine would make the documentation non-reproducible. They run offline, are
-executed while the documentation is built, and are also exercised in the
-explicit integration test tier. Their observations demonstrate API
-composition; they are not scientific claims about trained chess models.
+All notebooks use deterministic fixtures and run offline during the docs build.
 
 Feature notebooks
 -----------------


### PR DESCRIPTION
## Summary

- Put a complete first evaluation and focused example links at the top of the README.
- Reduce the documentation navigation to: Getting Started, Features, Tutorials, API Reference, and About.
- Keep detailed contracts as nested reference pages under Features.

## Validation

- Documentation build passed.
- Pre-commit hooks passed.